### PR TITLE
Added ability to read auxv

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -83,6 +83,7 @@ main(int argc, const char **argv)
         break;
       case WaitStatus::Execed: {
         tracer.get_current()->reopen_memfd();
+        target->read_auxv(wait);
         break;
       }
       case WaitStatus::Exited: {

--- a/src/target.h
+++ b/src/target.h
@@ -116,6 +116,11 @@ struct Target
   // Debug Symbols Related Logic
   void register_object_file(ObjectFile *obj) noexcept;
 
+  // we pass TaskWaitResult here, because want to be able to ASSERT that we just exec'ed.
+  // because we actually need to be at the *first* position on the stack, which, if we do at any other time we
+  // might (very likely) not be.
+  void read_auxv(TaskWaitResult &wait);
+
   template <typename T>
   std::optional<T>
   read_type_ptrace(TraceePointer<T> address, pid_t pid)
@@ -212,4 +217,6 @@ struct Target
 private:
   std::vector<CompilationUnitFile> m_files;
   std::unordered_map<std::string_view, Type> m_types;
+  std::optional<TPtr<void>> interpreter_base;
+  std::optional<TPtr<void>> entry;
 };

--- a/test/threads.cpp
+++ b/test/threads.cpp
@@ -11,9 +11,11 @@
 using ThreadPool = std::vector<std::thread>;
 
 int
-main(int argc, const char **)
+main(int argc, const char **argv)
 {
-
+  for (auto i = 1; i < argc; i++) {
+    printf("%s\n", argv[i]);
+  }
   Foo foo{};
   foo.a = 1;
   foo.b = 2;


### PR DESCRIPTION
Also extened the TraceePointer interface to be able to do pointer arithmetics (that also behave in intuitive ways).

The reason for reading AUXV is to be able to know where the "interpreter" - which typically is the dynamic linker/loader on linux called `/lib64/ld-linux-x86-64.so.2`) - has it's executable base address at.

Knowing this, we can start using tricks like, setting a breakpoint here so that we can trap the tracee when new symbols are loaded into it (for instance, when a shared object has been loaded at runtime).