### PR TITLE
Re-factor & New Requests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,10 @@ set(MIDAS_SOURCES
   src/ptrace.h
   src/task.cpp
   src/task.h
+  src/notify_pipe.cpp
+  src/notify_pipe.h
+  src/awaiter.cpp
+  src/awaiter.h
   src/breakpoint.cpp
   src/breakpoint.h
   src/posix/argslist.cpp

--- a/src/awaiter.cpp
+++ b/src/awaiter.cpp
@@ -1,0 +1,85 @@
+#include "awaiter.h"
+#include <sys/wait.h>
+
+void
+awaiter_thread_job(Notify &notifier, Tid task_leader, std::condition_variable &cv, std::mutex &m, bool &ready)
+{
+  int error_tries = 0;
+  while (true) {
+    siginfo_t info_ptr;
+    auto res = waitid(P_ALL, task_leader, &info_ptr, WEXITED | WSTOPPED | WNOWAIT);
+    if (res == -1) {
+      error_tries++;
+      ASSERT(error_tries <= 10, "Waitpid kept erroring out! {}: {}", errno, strerror(errno));
+      continue;
+    }
+    error_tries = 0;
+    // notify Tracer thread that it can pull out wait status info
+    notifier.notify();
+    {
+      std::unique_lock lk(m);
+      ready = false;
+      while (!ready)
+        cv.wait(lk);
+    }
+    ready = false;
+  }
+};
+
+AwaiterThread::AwaiterThread(Notify notifier, Tid task_leader) noexcept
+    : notifier(notifier), events_reaped(true), m{}, cv{}, initialized(false), should_cont(true)
+{
+
+  worker_thread = std::thread{[&n = this->notifier, &t = task_leader, &cv = cv, &m = m, &ready = events_reaped,
+                               &initialized = initialized, &c = should_cont]() {
+    int error_tries = 0;
+    {
+      std::unique_lock lk(m);
+      while (!initialized) {
+        cv.wait(lk);
+      }
+    }
+
+    while (c) {
+      siginfo_t info_ptr;
+      auto res = waitid(P_ALL, t, &info_ptr, WEXITED | WSTOPPED | WNOWAIT);
+      if (res == -1) {
+        error_tries++;
+        ASSERT(error_tries <= 10, "Waitpid kept erroring out! {}: {}", errno, strerror(errno));
+        continue;
+      }
+      error_tries = 0;
+      // notify Tracer thread that it can pull out wait status info
+      n.notify();
+      {
+        std::unique_lock lk(m);
+        ready = false;
+        while (!ready)
+          cv.wait(lk);
+      }
+      ready = false;
+    }
+  }};
+};
+
+AwaiterThread::~AwaiterThread() noexcept { worker_thread.join(); }
+
+void
+AwaiterThread::reaped_events() noexcept
+{
+  events_reaped = true;
+  cv.notify_one();
+}
+
+void
+AwaiterThread::start_awaiter_thread() noexcept
+{
+  this->initialized = true;
+  cv.notify_all();
+}
+
+void
+AwaiterThread::set_process_exited() noexcept
+{
+  should_cont = false;
+}

--- a/src/awaiter.h
+++ b/src/awaiter.h
@@ -1,0 +1,47 @@
+#pragma once
+#include "common.h"
+#include "notify_pipe.h"
+#include <condition_variable>
+#include <memory>
+#include <thread>
+
+using Notify = utils::Notifier::WriteEnd;
+
+class AwaiterThread
+{
+public:
+  using handle = std::unique_ptr<AwaiterThread>;
+  AwaiterThread() = delete;
+  /*
+   * - `notifier` - the notifier mechanism for informing the Tracer thread that something can be done
+   * - `task_leader` - the process space / task group leader / pid that we're awaiting on (and it's subsequent
+   * children)
+   */
+  AwaiterThread(Notify notifier, Tid task_leader) noexcept;
+  ~AwaiterThread() noexcept;
+
+  AwaiterThread(AwaiterThread &&) = delete;
+  NO_COPY(AwaiterThread);
+
+  /** Inform the AwaiterThread that the events it reported, we have seen and dealt with, allow AwaiterThread to
+   * listen for new events. If other threads of the process comes across WAIT events (i.e. become stopped), we will
+   * witness them during the next wait events cycle. The main purpose of this function is to not have AwaiterThread
+   * reporting events to Tracer that was actually caused by the Tracer thread itself; for instance, singlestepping
+   * out of a syscall exit, or a continue-stop-continue cycle, etc.*/
+  void reaped_events() noexcept;
+  /** Inform AwaiterThread that we've initialized all the state required for it to start listening for events. */
+  void start_awaiter_thread() noexcept;
+  /** Inform AwaiterThread that the process it is waiting on, no longer is executing, i.e. let AwaiterThread
+   * finish. */
+  void set_process_exited() noexcept;
+
+private:
+  Notify notifier;
+  bool events_reaped;
+  std::mutex m;
+  std::condition_variable cv;
+  bool initialized;
+  std::thread worker_thread;
+  // The keep-alive variable. If the task leader exits, should_cont = false and AwaiterThread is done.
+  bool should_cont;
+};

--- a/src/breakpoint.cpp
+++ b/src/breakpoint.cpp
@@ -1,6 +1,26 @@
 #include "breakpoint.h"
+#include <sys/ptrace.h>
 
 Breakpoint::Breakpoint(AddrPtr addr, u8 replaced_byte, u32 id, BreakpointType type) noexcept
     : ins_byte(replaced_byte), enabled(true), type(type), bp_id(id), times_hit(0), address(addr)
 {
+}
+
+void
+Breakpoint::enable(Tid tid) noexcept
+{
+  constexpr u64 bkpt = 0xcc;
+  const auto read_value = ptrace(PTRACE_PEEKDATA, tid, address.get(), nullptr);
+  const u64 installed_bp = ((read_value & ~0xff) | bkpt);
+  ptrace(PTRACE_POKEDATA, tid, address.get(), installed_bp);
+  enabled = true;
+}
+
+void
+Breakpoint::disable(Tid tid) noexcept
+{
+  const auto read_value = ptrace(PTRACE_PEEKDATA, tid, address.get(), nullptr);
+  const u64 restore = ((read_value & ~0xff) | ins_byte);
+  ptrace(PTRACE_POKEDATA, tid, address.get(), restore);
+  enabled = false;
 }

--- a/src/breakpoint.h
+++ b/src/breakpoint.h
@@ -18,6 +18,9 @@ public:
   Breakpoint &operator=(const Breakpoint &) noexcept = default;
   Breakpoint &operator=(Breakpoint &&) noexcept = default;
 
+  void enable(Tid tid) noexcept;
+  void disable(Tid tid) noexcept;
+
   u8 ins_byte;
   bool enabled : 1;
   BreakpointType type : 7;

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -39,6 +39,16 @@ waitpid_nonblock(pid_t tid) noexcept
   return WaitPid{waited_pid, status};
 }
 
+Option<WaitPid>
+waitpid_block(pid_t tid) noexcept
+{
+  int status;
+  const auto waited_pid = waitpid(tid, &status, 0);
+  if (waited_pid == 0 || waited_pid == -1)
+    return Option<WaitPid>{};
+  return WaitPid{waited_pid, status};
+}
+
 std::string_view
 syscall_name(u64 syscall_number)
 {

--- a/src/common.h
+++ b/src/common.h
@@ -48,13 +48,19 @@ struct WaitPid
   int status;
 };
 
-#define FOR_EVER for (;;)
+enum class TargetSession
+{
+  Launched,
+  Attached
+};
 
 /** `wait`'s for `tid` in a non-blocking way and also if the operation returns a result, leaves the wait value in
  * place so that `wait` can be called again to reap it. If no child was waited on returns `none`. */
 Option<WaitPid> waitpid_peek(pid_t tid) noexcept;
 /** `wait`'s for `tid` in a non-blocking way. If waiting on `tid` yielded no wait status, returns `none` */
 Option<WaitPid> waitpid_nonblock(pid_t tid) noexcept;
+
+Option<WaitPid> waitpid_block(pid_t tid) noexcept;
 
 // "remove_cvref_t" is an absolutely retarded name. We therefore call it `ActualType<T>` to signal clear intent.
 template <typename T> using ActualType = std::remove_cvref_t<T>;

--- a/src/interface/dap/commands.cpp
+++ b/src/interface/dap/commands.cpp
@@ -286,7 +286,6 @@ Launch::Launch(Path &&program, std::vector<std::string> &&program_args) noexcept
 UIResultPtr
 Launch::execute(Tracer *tracer) noexcept
 {
-  fmt::println("[Launch] {} with args {{ {} }}", program.c_str(), fmt::join(program_args, ","));
   tracer->launch(std::move(program), std::move(program_args));
   return new LaunchResponse{true, this};
 }

--- a/src/interface/dap/commands.cpp
+++ b/src/interface/dap/commands.cpp
@@ -149,7 +149,7 @@ ReadMemoryResponse::serialize(int seq) const noexcept
 {
   if (success) {
     return fmt::format(
-        R"({{ "seq": {}, "response_seq": {}, "type": "response", "success": true, "command": "readMemory", "body": {{ "address": {}, "unreadableBytes": {}, "data": {} }} }})",
+        R"({{ "seq": {}, "response_seq": {}, "type": "response", "success": true, "command": "readMemory", "body": {{ "address": "{}", "unreadableBytes": {}, "data": "{}" }} }})",
         seq, response_seq, first_readable_address, unreadable_bytes, data_base64);
   } else {
     TODO("non-success for ReadMemory");
@@ -374,7 +374,7 @@ parse_command(Command cmd, nlohmann::json &&args) noexcept
     ASSERT(args.contains("memoryReference") && args.contains("count"),
            "args didn't contain memoryReference or count");
     std::string_view addr_str;
-    args.at("instructionReference").get_to(addr_str);
+    args.at("memoryReference").get_to(addr_str);
     auto addr = to_addr(addr_str);
     auto offset = 0;
     if (args.contains("offset")) {

--- a/src/interface/dap/commands.cpp
+++ b/src/interface/dap/commands.cpp
@@ -184,6 +184,9 @@ ConfigurationDoneResponse::serialize(int seq) const noexcept
 UIResultPtr
 ConfigurationDone::execute(Tracer *tracer) noexcept
 {
+  fmt::println("Configuration steps done.");
+  tracer->get_current()->set_all_running(RunType::Continue);
+  tracer->get_current()->start_awaiter_thread();
   return new ConfigurationDoneResponse{true, this};
 }
 
@@ -192,6 +195,7 @@ Initialize::Initialize(nlohmann::json &&arguments) noexcept : args(std::move(arg
 UIResultPtr
 Initialize::execute(Tracer *tracer) noexcept
 {
+  fmt::println("initializing...");
   return new InitializeResponse{true, this};
 }
 
@@ -210,6 +214,7 @@ Disconnect::Disconnect(bool restart, bool terminate_debuggee, bool suspend_debug
 UIResultPtr
 Disconnect::execute(Tracer *tracer) noexcept
 {
+  tracer->kill_all_targets();
   return new DisconnectResponse{true, this};
 }
 
@@ -281,7 +286,9 @@ Launch::Launch(Path &&program, std::vector<std::string> &&program_args) noexcept
 UIResultPtr
 Launch::execute(Tracer *tracer) noexcept
 {
-  TODO("Launch::execute (see main.cpp for what it needs to do ish)");
+  fmt::println("[Launch] {} with args {{ {} }}", program.c_str(), fmt::join(program_args, ","));
+  tracer->launch(std::move(program), std::move(program_args));
+  return new LaunchResponse{true, this};
 }
 
 std::string

--- a/src/interface/dap/interface.cpp
+++ b/src/interface/dap/interface.cpp
@@ -83,9 +83,9 @@ static constexpr std::string_view strings[]{
 
 using json = nlohmann::json;
 
-DAP::DAP(Tracer *tracer, int tracer_input_fd, int tracer_output_fd, int master_pty_fd,
+DAP::DAP(Tracer *tracer, int tracer_input_fd, int tracer_output_fd,
          utils::Notifier::WriteEnd command_notifier) noexcept
-    : tracer{tracer}, tracer_in_fd(tracer_input_fd), tracer_out_fd(tracer_output_fd), master_pty_fd(master_pty_fd),
+    : tracer{tracer}, tracer_in_fd(tracer_input_fd), tracer_out_fd(tracer_output_fd),
       keep_running(true), output_message_lock{}, events_queue{}, seq(0), command_notifier(command_notifier)
 {
   auto [r, w] = utils::Notifier::notify_pipe();
@@ -93,9 +93,7 @@ DAP::DAP(Tracer *tracer, int tracer_input_fd, int tracer_output_fd, int master_p
   posted_evt_listener = r;
   buffer = mmap_buffer<char>(4096);
   tracee_stdout_buffer = mmap_buffer<char>(4096 * 3);
-  auto flags = fcntl(master_pty_fd, F_GETFL);
-  VERIFY(flags != -1, "Failed to get pty flags");
-  VERIFY(fcntl(master_pty_fd, F_SETFL, flags | FNDELAY | FNONBLOCK) != -1, "Failed to set FNDELAY on pty");
+
   log_file = std::fstream{"/home/cx/dev/foss/cx/dbm/build-debug/bin/dap.log",
                           std::ios_base::in | std::ios_base::out | std::ios_base::trunc};
   if (!log_file.is_open())
@@ -138,10 +136,13 @@ DAP::run_ui_loop()
 
   while (keep_running || cleanup_times > 0) {
     epoll_event events[5];
+
+    const auto master_pty = current_tty();
+
     struct pollfd pfds[3]{
         cfg_read_poll(tracer_in_fd, 0),
         cfg_read_poll(posted_evt_listener, 0),
-        cfg_read_poll(master_pty_fd, 0),
+        cfg_read_poll(master_pty, 0),
     };
 
     auto ready = poll(pfds, 3, 100);
@@ -204,8 +205,8 @@ DAP::run_ui_loop()
             write_protocol_message(protocol_msg);
             delete evt;
           }
-        } else if (pfds[i].fd == master_pty_fd && (pfds[i].revents & POLLIN)) {
-          auto bytes_read = read(master_pty_fd, tracee_stdout_buffer, 4096 * 3);
+        } else if (pfds[i].fd == master_pty && (pfds[i].revents & POLLIN)) {
+          auto bytes_read = read(master_pty, tracee_stdout_buffer, 4096 * 3);
           if (bytes_read == -1)
             continue;
           std::string_view data{tracee_stdout_buffer, static_cast<u64>(bytes_read)};
@@ -256,6 +257,28 @@ void
 DAP::display_result(std::string_view str) const noexcept
 {
   VERIFY(write(tracer_out_fd, str.data(), str.size()) != -1, "Failed to write '{}'", str);
+}
+
+void
+DAP::add_tty(int master_pty_fd) noexcept
+{
+  // todo(simon): when we add a new pty, what we need to do
+  // is somehow find a way to re-route (temporarily) the other pty's to /dev/null, because we don't care for them
+  // however, we must also be able to _restore_ those pty's from that re-routing. I'm not sure that works, or if
+  // it's possible but it would be nice.
+  auto flags = fcntl(master_pty_fd, F_GETFL);
+  VERIFY(flags != -1, "Failed to get pty flags");
+  VERIFY(fcntl(master_pty_fd, F_SETFL, flags | FNDELAY | FNONBLOCK) != -1, "Failed to set FNDELAY on pty");
+  current_tty_idx = tty_fds.size();
+  tty_fds.push_back(master_pty_fd);
+}
+
+int
+DAP::current_tty() noexcept
+{
+  if (tty_fds.empty())
+    return -1;
+  return tty_fds[current_tty_idx];
 }
 
 } // namespace ui::dap

--- a/src/interface/dap/interface.cpp
+++ b/src/interface/dap/interface.cpp
@@ -179,7 +179,9 @@ DAP::run_ui_loop()
                 std::string_view cmd_name;
                 obj["command"].get_to(cmd_name);
                 ASSERT(obj.contains("arguments"), "Request did not contain an 'arguments' field: {}", packet);
+                ASSERT(obj.contains("seq"), "Request did not contain seq field");
                 auto cmd = parse_command(parse_command_type(cmd_name), std::move(obj["arguments"]));
+                cmd->seq = obj["seq"];
                 tracer->accept_command(cmd);
                 parsed_commands = true;
               }

--- a/src/interface/dap/interface.h
+++ b/src/interface/dap/interface.h
@@ -106,7 +106,7 @@ private:
 class DAP
 {
 public:
-  explicit DAP(Tracer *tracer, int tracer_input_fd, int tracer_output_fd, int output_fd,
+  explicit DAP(Tracer *tracer, int tracer_input_fd, int tracer_output_fd,
                utils::Notifier::WriteEnd io_write) noexcept;
   ~DAP() = default;
 
@@ -123,17 +123,25 @@ public:
   // Fulfill the `UI` concept in ui_result.h
   void display_result(std::string_view str) const noexcept;
 
+  void add_tty(int master_pty_fd) noexcept;
+  int current_tty() noexcept;
+
 private:
   UIResultPtr pop_event() noexcept;
   void write_protocol_message(std::string_view msg) noexcept;
   u64 new_result_id() noexcept;
+
+  // all the tty's we have connected.
+  // Note that, we only ever listen/have one active at one time. Interleaving std output from different processes
+  // would be insane.
+  std::vector<int> tty_fds;
+  u64 current_tty_idx;
 
   utils::Notifier::WriteEnd posted_event_notifier;
   utils::Notifier::ReadEnd posted_evt_listener;
   Tracer *tracer;
   int tracer_in_fd;
   int tracer_out_fd;
-  int master_pty_fd;
   bool keep_running;
   char *buffer;
   // A buffer of

--- a/src/interface/ui_command.h
+++ b/src/interface/ui_command.h
@@ -1,9 +1,13 @@
 #pragma once
-#include "ui_result.h"
+#include <cstdint>
+#include <string_view>
 
 class Tracer;
 
 namespace ui {
+struct UIResult;
+using UIResultPtr = UIResult *;
+
 #if defined(MDB_DEBUG)
 #define DEFINE_NAME(Type)                                                                                         \
   constexpr std::string_view name() noexcept override final                                                       \
@@ -20,6 +24,7 @@ public:
   virtual ~UICommand() = default;
   virtual UIResultPtr execute(Tracer *tracer) noexcept = 0;
 
+  std::uint64_t seq;
 #if defined(MDB_DEBUG)
   constexpr virtual std::string_view name() noexcept = 0;
 #endif

--- a/src/interface/ui_result.h
+++ b/src/interface/ui_result.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "ui_command.h"
 #include <concepts>
 #include <cstdint>
 #include <string>
@@ -14,6 +15,11 @@ concept UI = requires(UIType ui) {
 namespace ui {
 struct UIResult
 {
+  UIResult() = default;
+  UIResult(bool success, UICommandPtr cmd = nullptr) noexcept
+      : success(success), response_seq((cmd != nullptr) ? cmd->seq : 0)
+  {
+  }
   virtual ~UIResult() = default;
   virtual std::string serialize(int monotonic_id) const noexcept = 0;
 
@@ -24,6 +30,7 @@ struct UIResult
     output->display_result(serialize(output->new_result_id()));
   }
   bool success;
+  std::uint64_t response_seq;
 };
 
 // Makes it *somewhat* easier to re-factoer later, if we want to use shared_ptr or unique_ptr here

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,120 +53,50 @@ idx()
   return std::to_underlying(AP);
 }
 
+termios Tracer::original_tty = {};
+winsize Tracer::ws = {};
+
 int
 main(int argc, const char **argv)
 {
-
-  if (argc < 2) {
-    fmt::print("Usage: mdb <binary>\n");
-    exit(EXIT_FAILURE);
-  }
-
-  fs::path p{argv[1]};
-  if (!fs::exists(p)) {
-    fmt::print("{} does not exist\n", p.c_str());
-    exit(EXIT_FAILURE);
-  }
-
   ScopedFd log_file = ScopedFd::open("/home/cx/dev/foss/cx/dbm/build-debug/bin/mdb.log", O_CREAT | O_RDWR);
-  PosixArgsList args_list{std::vector<std::string>{argv + 1, argv + argc}};
+  VERIFY(tcgetattr(STDIN_FILENO, &Tracer::original_tty) != -1, "Failed to get attributes for stdin");
+  VERIFY(ioctl(STDIN_FILENO, TIOCGWINSZ, &Tracer::ws) >= 0, "Failed to get winsize of stdin");
 
-  termios original_tty;
-  winsize ws;
-  VERIFY(tcgetattr(STDIN_FILENO, &original_tty) != -1, "Failed to get attributes for stdin");
-  VERIFY(ioctl(STDIN_FILENO, TIOCGWINSZ, &ws) >= 0, "Failed to get winsize of stdin");
+  auto [io_read, io_write] = utils::Notifier::notify_pipe();
 
-  auto fork_result = pty_fork(&original_tty, &ws);
+  utils::NotifyManager notifiers{io_read};
+  Tracer::Instance = new Tracer{io_read, &notifiers};
+  auto &tracer = *Tracer::Instance;
+  // spawn the UI thread that runs our UI loop
+  bool ui_thread_setup = false;
 
-  switch (fork_result.index()) {
-  case 0: {
-    const auto [cmd, args] = args_list.get_command();
-    if (personality(ADDR_NO_RANDOMIZE) == -1) {
-      PANIC("Failed to set ADDR_NO_RANDOMIZE!");
-    }
-    // ptrace(PTRACE_TRACEME, 0, 0, 0);
-    raise(SIGSTOP);
-    execv(cmd, args);
-    break;
+  std::thread ui_thread{[&io_write = io_write, &ui_thread_setup]() {
+    ui::dap::DAP ui_interface{Tracer::Instance, STDIN_FILENO, STDOUT_FILENO, io_write};
+    Tracer::Instance->set_ui(&ui_interface);
+    ui_thread_setup = true;
+    ui_interface.run_ui_loop();
+  }};
+
+  while (!ui_thread_setup) {
   }
-  default: {
-    const auto result = std::get<PtyParentResult>(fork_result);
 
-    auto [wait_read, wait_write] = utils::Notifier::notify_pipe();
-    auto [io_read, io_write] = utils::Notifier::notify_pipe();
-
-    utils::NotifyManager<2> notifiers{std::array<utils::Notifier::ReadEnd, 2>{wait_read, io_read},
-                                      std::array<std::string_view, 2>{"Awaiter Thread", "IO Thread"}};
-
-    Tracer::Instance = new Tracer{wait_read, io_read};
-    auto &tracer = *Tracer::Instance;
-    // spawn the UI thread that runs our UI loop
-    bool ui_thread_setup = false;
-
-    std::thread ui_thread{[fd = result.fd, &io_write = io_write, &ui_thread_setup]() {
-      ui::dap::DAP ui_interface{Tracer::Instance, STDIN_FILENO, STDOUT_FILENO, fd, io_write};
-      Tracer::Instance->set_ui(&ui_interface);
-      ui_thread_setup = true;
-      ui_interface.run_ui_loop();
-    }};
-    bool waiter_thread_setup = false;
-    std::thread awaiter_thread([&wait_write = wait_write, tl = result.pid, &waiter_thread_setup]() {
-      int error_tries = 0;
-      waiter_thread_setup = true;
-      while (!exit_debug_session) {
-
-        siginfo_t info_ptr;
-        auto res = waitid(P_ALL, tl, &info_ptr, WEXITED | WSTOPPED | WNOWAIT);
-        if (res == -1) {
-          error_tries++;
-          ASSERT(error_tries <= 10, "Waitpid kept erroring out! {}: {}", errno, strerror(errno));
-          continue;
-        }
-        error_tries = 0;
-        // notify Tracer thread that it can pull out wait status info
-        wait_write.notify();
-
-        // Now wait for Tracer thread to notify us that it has handled all wait statuses it can
-        // This is also very important for another reason; When the tracer thread does it's magic
-        // it might for instance do start-stop-restart-stop LWP's for a number of reasons - while doing that,
-        // we can't have the awaiter thread yelling at us that there are a bunch of new await results available
-        // - so we tell this puppy to go to sleep here and let the Tracer thread wake it up afterwards
-        {
-          std::unique_lock lk(m);
-          ready = false;
-          while (!ready)
-            cv.wait(lk);
-        }
-        ready = false;
+  std::vector<utils::NotifyResult> notify_events{};
+  for (;;) {
+    if (notifiers.poll(1000)) {
+      notifiers.has_wait_ready(notify_events);
+      for (const auto target : notify_events) {
+        // handle await events on `target`
+        tracer.wait_for_tracee_events(target.pid);
       }
-    });
-
-    while (!waiter_thread_setup || !ui_thread_setup) {
-    }
-    Tracer::Instance->add_target_set_current(result.pid, p);
-    bool stopped = true;
-    using enum AwaitablePipes;
-    for (; tracer.get_current()->execution_not_ended();) {
-      if (notifiers.poll(1000)) {
-        if (notifiers.has_notification<AwaiterThread>()) {
-          stopped = tracer.wait_for_tracee_events();
-          ready = true;
-          cv.notify_one();
-        }
-        if (notifiers.has_notification<IOThread>()) {
-          tracer.execute_pending_commands();
-        }
-      }
-      if (stopped) {
-        fmt::println("Tracer reported we're stopped?");
+      // handle IO event
+      if (notifiers.has_io_ready()) {
+        tracer.execute_pending_commands();
       }
     }
-    exit_debug_session = true;
-    Tracer::Instance->kill_ui();
-    ui_thread.join();
-    awaiter_thread.join();
-    break;
   }
-  }
+  exit_debug_session = true;
+  Tracer::Instance->kill_ui();
+  ui_thread.join();
   fmt::println("Exited...");
 }

--- a/src/notify_pipe.cpp
+++ b/src/notify_pipe.cpp
@@ -1,0 +1,72 @@
+#include "notify_pipe.h"
+
+struct pollfd;
+
+namespace utils {
+
+/*static*/ Notifier
+Notifier::notify_pipe() noexcept
+{
+  int notify_pipe[2];
+  ASSERT(pipe(notify_pipe) != -1, "Failed to set up notifier pipe {}", strerror(errno));
+  auto flags = fcntl(notify_pipe[0], F_GETFL);
+  VERIFY(flags != -1, "Failed to get flags for read-end of pipe");
+  VERIFY(-1 != fcntl(notify_pipe[0], F_SETFL, flags | O_NONBLOCK), "Failed to set non-blocking for pipe");
+  return Notifier{.read = ReadEnd{notify_pipe[0]}, .write = WriteEnd{notify_pipe[1]}};
+}
+
+NotifyManager::NotifyManager(Notifier::ReadEnd io_read) noexcept : notifiers(), notifier_names(), fd_to_target()
+{
+  notifier_names.push_back("IO Thread");
+  notifiers.push_back(io_read);
+  pollfds.push_back({.fd = io_read.fd, .events = EPOLLIN, .revents = 0});
+}
+
+void
+NotifyManager::add_notifier(Notifier::ReadEnd notifier, std::string name, Tid task_leader) noexcept
+{
+  notifiers.push_back(notifier);
+  notifier_names.push_back(name);
+  pollfds.push_back({.fd = notifier.fd, .events = EPOLLIN, .revents = 0});
+  fd_to_target[notifier.fd] = task_leader;
+}
+
+bool
+NotifyManager::poll(int timeout) noexcept
+{
+  auto ready = ::poll(pollfds.data(), pollfds.size(), timeout);
+  return ready > 0;
+}
+
+bool
+NotifyManager::has_io_ready() noexcept
+{
+  const auto ok = (pollfds[0].revents & POLLIN) == POLLIN;
+  if (ok) {
+    char c;
+    auto res = ::read(pollfds[0].fd, &c, 1);
+    ASSERT(res != -1 && errno != EAGAIN, "Attempting to read from pipe when it would block");
+  }
+  pollfds[0].revents = 0;
+  pollfds[0].events = POLLIN;
+  pollfds[0].fd = notifiers[0].fd;
+  return ok;
+}
+
+void
+NotifyManager::has_wait_ready(std::vector<NotifyResult> &result)
+{
+  result.clear();
+  for (auto i = 1ul; i < pollfds.size(); i++) {
+    const auto ok = (pollfds[i].revents & POLLIN) == POLLIN;
+    if (ok) {
+      result.push_back(NotifyResult{.pid = fd_to_target[pollfds[i].fd]});
+      char c;
+      auto res = ::read(pollfds[i].fd, &c, 1);
+      ASSERT(res != -1 && errno != EAGAIN, "Attempting to read from pipe when it would block");
+    }
+    pollfds[i].revents = 0;
+    pollfds[i].events = POLLIN;
+  }
+}
+} // namespace utils

--- a/src/target.h
+++ b/src/target.h
@@ -14,6 +14,7 @@
 #include <sys/ptrace.h>
 #include <sys/uio.h>
 #include <sys/user.h>
+#include <thread>
 #include <type_traits>
 #include <unistd.h>
 #include <unordered_map>
@@ -154,6 +155,9 @@ struct Target
   // thing
   void reset_addr_breakpoints(std::vector<TPtr<void>> addresses) noexcept;
   void reset_fn_breakpoints(std::vector<std::string_view> fn_names) noexcept;
+
+  bool kill() noexcept;
+  bool terminate_gracefully() noexcept;
 
   // todo(simon): These need re-factoring. They're only confusing as hell and misleading.
   void task_wait_emplace(int status, TaskWaitResult *wait) noexcept;

--- a/src/task.h
+++ b/src/task.h
@@ -52,7 +52,7 @@ struct TaskInfo
   bool stopped : 1;
   bool signal_in_flight : 1;
   bool stepping : 1;
-  bool stopped_by_tracer : 1;
+  bool ptrace_stop : 1;
   bool initialized : 1;
   pid_t tid;
   std::optional<TaskWaitResult> wait_status;
@@ -70,6 +70,7 @@ struct TaskInfo
   void set_stop() noexcept;
   void initialize() noexcept;
   bool can_continue() noexcept;
+  void set_pc(TPtr<void> pc) noexcept;
 
   /*
    * Checks if this task is stopped, either `stopped_by_tracer` or `stopped` by some execution event, like a signal
@@ -127,7 +128,7 @@ template <> struct formatter<TaskInfo>
     }
 
     return fmt::format_to(ctx.out(), "[Task {}] {{ stopped: {}, tracer_stopped: {}, wait_status: {} }}", task.tid,
-                          task.stopped, task.stopped_by_tracer, wait_status);
+                          task.stopped, task.ptrace_stop, wait_status);
   }
 };
 

--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -1,6 +1,8 @@
 #include "tracer.h"
 #include "./interface/dap/interface.h"
 #include "common.h"
+#include "fmt/format.h"
+#include "forker.h"
 #include "interface/dap/events.h"
 #include "interface/ui_command.h"
 #include "interface/ui_result.h"
@@ -326,4 +328,11 @@ Tracer::execute_pending_commands() noexcept
     executed_commands++;
   }
   fmt::println("Executed {} commands", executed_commands);
+}
+
+void
+Tracer::launch(Path &&program, std::vector<std::string> &&prog_args) noexcept
+{
+  TODO(fmt::format("Service the Launch Request for program: {}, args: {{ {} }}", program.c_str(),
+                   fmt::join(prog_args, ",")));
 }

--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -2,13 +2,14 @@
 #include "./interface/dap/interface.h"
 #include "common.h"
 #include "fmt/format.h"
-#include "forker.h"
 #include "interface/dap/events.h"
+#include "interface/pty.h"
 #include "interface/ui_command.h"
 #include "interface/ui_result.h"
 #include "lib/lockguard.h"
 #include "lib/spinlock.h"
 #include "notify_pipe.h"
+#include "posix/argslist.h"
 #include "ptrace.h"
 #include "symbolication/cu.h"
 #include "symbolication/elf.h"
@@ -23,6 +24,7 @@
 #include <nlohmann/json.hpp>
 #include <ranges>
 #include <sys/mman.h>
+#include <sys/personality.h>
 #include <sys/ptrace.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
@@ -31,8 +33,8 @@
 
 Tracer *Tracer::Instance = nullptr;
 
-Tracer::Tracer(utils::Notifier::ReadEnd wait_pipe, utils::Notifier::ReadEnd io_thread_pipe) noexcept
-    : wait_pipe(wait_pipe), io_thread_pipe(io_thread_pipe)
+Tracer::Tracer(utils::Notifier::ReadEnd io_thread_pipe, utils::NotifyManager *events_notifier) noexcept
+    : io_thread_pipe(io_thread_pipe), events_notifier(events_notifier)
 {
   ASSERT(Tracer::Instance == nullptr,
          "Multiple instantiations of the Debugger - Design Failure, this = 0x{:x}, older instance = 0x{:x}",
@@ -47,8 +49,8 @@ Tracer::load_and_process_objfile(pid_t target_pid, const Path &objfile_path) noe
   ASSERT(mmap_objectfile(objfile_path) == AddObjectResult::OK, "Failed to load object file");
   const auto obj_file = object_files.back();
   Elf::parse_objfile(obj_file);
-  auto &target = get_target(target_pid);
-  target.register_object_file(obj_file);
+  auto target = get_target(target_pid);
+  target->register_object_file(obj_file);
   CompilationUnitBuilder cu_builder{obj_file};
   std::vector<std::unique_ptr<CUProcessor>> cu_processors{};
   auto total = cu_builder.build_cu_headers();
@@ -75,10 +77,11 @@ Tracer::load_and_process_objfile(pid_t target_pid, const Path &objfile_path) noe
 }
 
 void
-Tracer::add_target_set_current(pid_t task_leader, const Path &path) noexcept
+Tracer::add_target_set_current(pid_t task_leader, const Path &path, TargetSession session) noexcept
 {
-  static pid_t leader_kill = task_leader;
-  targets.push_back(std::make_unique<Target>(task_leader, true));
+  auto [io_read, io_write] = utils::Notifier::notify_pipe();
+  events_notifier->add_notifier(io_read, path.string(), task_leader);
+  targets.push_back(std::make_unique<Target>(task_leader, io_write, session, true));
   auto evt = new ui::dap::OutputEvent{
       "console"sv, fmt::format("Task ({}) {} created (task leader: {})", 1, task_leader, task_leader)};
   Tracer::Instance->post_event(evt);
@@ -86,7 +89,6 @@ Tracer::add_target_set_current(pid_t task_leader, const Path &path) noexcept
   load_and_process_objfile(task_leader, path);
   PTRACE_OR_PANIC(PTRACE_SEIZE, task_leader, 0, 0);
   new_target_set_options(task_leader);
-  atexit([]() { ptrace(PTRACE_KILL, leader_kill, 0, 0); });
 }
 
 AddObjectResult
@@ -115,13 +117,13 @@ Tracer::thread_exited(LWP lwp, int) noexcept
   dap->post_event(evt);
 }
 
-Target &
+Target *
 Tracer::get_target(pid_t pid) noexcept
 {
   auto it = std::ranges::find_if(targets, [&pid](auto &t) { return t->task_leader == pid; });
   ASSERT(it != std::end(targets), "Could not find target {} pid", pid);
 
-  return **it;
+  return it->get();
 }
 
 Target *
@@ -138,20 +140,20 @@ Tracer::init_io_thread() noexcept
 void
 Tracer::interrupt(LWP lwp) noexcept
 {
-  auto &target = get_target(lwp.pid);
-  for (auto &task : target.threads) {
+  auto target = get_target(lwp.pid);
+  for (auto &task : target->threads) {
     if (!task.is_stopped()) {
       PTRACE_OR_PANIC(PTRACE_INTERRUPT, task.tid, nullptr, nullptr);
       task.set_stop();
-      task.stopped_by_tracer = true;
+      task.ptrace_stop = true;
     }
   }
 }
 
 bool
-Tracer::wait_for_tracee_events() noexcept
+Tracer::wait_for_tracee_events(Tid target_pid) noexcept
 {
-  auto target = get_current();
+  auto target = get_target(target_pid);
   auto wait_res = target->wait_pid(nullptr);
   if (!wait_res.has_value())
     return false;
@@ -173,6 +175,7 @@ Tracer::wait_for_tracee_events() noexcept
     switch (target->handle_stopped_for(task)) {
     case ActionOnEvent::ShouldContinue: {
       task->set_running(RunType::Continue);
+      stopped = false;
       break;
     }
     case ActionOnEvent::StopTracee: {
@@ -188,7 +191,7 @@ Tracer::wait_for_tracee_events() noexcept
             PTRACE_OR_PANIC(PTRACE_INTERRUPT, task.tid, nullptr, nullptr);
             // we can block, because we know we sent this signal.
             waitpid(task.tid, &stat, 0);
-            task.stopped_by_tracer = true;
+            task.ptrace_stop = true;
           } else {
             // task *was* stopped when we peeked - set stopped, but not by us
             task.stopped = true;
@@ -245,7 +248,138 @@ Tracer::wait_for_tracee_events() noexcept
             PTRACE_OR_PANIC(PTRACE_INTERRUPT, task.tid, nullptr, nullptr);
             // we can block, because we know we sent this signal.
             waitpid(task.tid, &stat, 0);
-            task.stopped_by_tracer = true;
+            task.ptrace_stop = true;
+          } else {
+            // task *was* stopped when we peeked - set stopped, but not by us
+            task.stopped = true;
+          }
+        }
+      }
+    } else {
+      task->set_running(RunType::Continue);
+    }
+
+    break;
+  }
+  case WaitStatus::Forked:
+    break;
+  case WaitStatus::VForked:
+    break;
+  case WaitStatus::VForkDone:
+    break;
+  case WaitStatus::Signalled:
+    task->stopped = true;
+    break;
+  case WaitStatus::SyscallEntry:
+    break;
+  case WaitStatus::SyscallExit:
+    break;
+  default:
+    stopped = false;
+  }
+
+  target->reaped_events();
+  return stopped;
+}
+
+bool
+Tracer::wait_for_tracee_events() noexcept
+{
+  auto target = get_current();
+  auto wait_res = target->wait_pid(nullptr);
+  if (!wait_res.has_value())
+    return false;
+  auto wait = *wait_res;
+  // For now, we only support "all-stop" mode
+  bool do_not_interrupt_leader = false;
+  bool stopped = false;
+  if (!target->has_task(wait.waited_pid)) {
+    target->new_task(wait.waited_pid, true);
+    do_not_interrupt_leader = true;
+  }
+  target->register_task_waited(wait);
+  auto task = target->get_task(wait.waited_pid);
+  task->stopped = true;
+  switch (wait.ws) {
+  case WaitStatus::Stopped: {
+    target->cache_registers(task->tid);
+    // some pretty involved functionality needs to be called here, I think.
+    switch (target->handle_stopped_for(task)) {
+    case ActionOnEvent::ShouldContinue: {
+      task->set_running(RunType::Continue);
+      break;
+    }
+    case ActionOnEvent::StopTracee: {
+      stopped = true;
+      for (auto &task : target->threads) {
+        if (task.tid != wait.waited_pid && (do_not_interrupt_leader ? task.tid != target->task_leader : true)) {
+          int stat;
+          // peek wait statuses
+          const auto peek_waited_tid = waitpid(task.tid, &stat, WNOHANG | WNOWAIT);
+          // if task has no wait status waiting, it's most likely running
+          // therefore we need to interrupt it.
+          if (peek_waited_tid == 0) {
+            PTRACE_OR_PANIC(PTRACE_INTERRUPT, task.tid, nullptr, nullptr);
+            // we can block, because we know we sent this signal.
+            waitpid(task.tid, &stat, 0);
+            task.ptrace_stop = true;
+          } else {
+            // task *was* stopped when we peeked - set stopped, but not by us
+            task.stopped = true;
+          }
+        }
+      }
+      break;
+    }
+    }
+  } break;
+  case WaitStatus::Execed: {
+    get_current()->reopen_memfd();
+    target->cache_registers(task->tid);
+    target->read_auxv(wait);
+    break;
+  }
+  case WaitStatus::Exited: {
+    target->reap_task(task);
+    break;
+  }
+  case WaitStatus::Cloned: {
+    // we always have to cache these registers, because we need them to pull out some information
+    // about the new clone
+    auto &registers = target->cache_registers(task->tid);
+    const TraceePointer<clone_args> ptr = sys_arg<SysRegister::RDI>(registers);
+    const auto res = target->read_type(ptr);
+    // Nasty way to get PID, but, in doing so, we also get stack size + stack location for new thread
+    auto np = target->read_type(TPtr<pid_t>{res.parent_tid});
+#ifdef MDB_DEBUG
+    long new_pid = 0;
+    PTRACE_OR_PANIC(PTRACE_GETEVENTMSG, wait.waited_pid, 0, &new_pid);
+    ASSERT(np == new_pid, "Inconsistent pid values retrieved, expected {} but got {}", np, new_pid);
+#endif
+    if (!target->has_task(np)) {
+      target->new_task(np, true);
+    }
+    // by this point, the task has cloned _and_ it's continuable because the parent has been told
+    // that "hey, we're ok". Why on earth a pre-finished clone can be waited on, I will never know.
+    target->get_task(np)->initialize();
+    // task backing storage may have re-allocated and invalidated this pointer.
+    task = target->get_task(wait.waited_pid);
+    target->set_task_vm_info(np, TaskVMInfo::from_clone_args(res));
+    if (target->should_stop_on_clone()) {
+      stopped = true;
+      target->cache_registers(np);
+      for (auto &task : target->threads) {
+        if (task.tid != wait.waited_pid && task.tid != np) {
+          int stat;
+          // peek wait statuses
+          const auto peek = waitpid_peek(task.tid);
+          // if task has no wait status waiting, it's most likely running
+          // therefore we need to interrupt it.
+          if (!peek) {
+            PTRACE_OR_PANIC(PTRACE_INTERRUPT, task.tid, nullptr, nullptr);
+            // we can block, because we know we sent this signal.
+            waitpid(task.tid, &stat, 0);
+            task.ptrace_stop = true;
           } else {
             // task *was* stopped when we peeked - set stopped, but not by us
             task.stopped = true;
@@ -308,7 +442,6 @@ void
 Tracer::execute_pending_commands() noexcept
 {
   ui::UICommandPtr pending_command = nullptr;
-  int executed_commands = 0;
   while (!command_queue.empty()) {
     // keep the lock as minimum of a time span as possible
     {
@@ -317,22 +450,88 @@ Tracer::execute_pending_commands() noexcept
       command_queue.pop();
     }
     ASSERT(pending_command != nullptr, "Expected a command but got null");
-#ifdef MDB_DEBUG
-    fmt::println("Executing {}", pending_command->name());
-#endif
     auto result = pending_command->execute(this);
 
     dap->post_event(result);
     delete pending_command;
     pending_command = nullptr;
-    executed_commands++;
   }
-  fmt::println("Executed {} commands", executed_commands);
 }
 
 void
 Tracer::launch(Path &&program, std::vector<std::string> &&prog_args) noexcept
 {
-  TODO(fmt::format("Service the Launch Request for program: {}, args: {{ {} }}", program.c_str(),
-                   fmt::join(prog_args, ",")));
+  std::vector<std::string> posix_cmd_args{};
+  posix_cmd_args.push_back(program);
+  for (auto &&arg : prog_args) {
+    posix_cmd_args.push_back(arg);
+  }
+  PosixArgsList args_list{std::move(posix_cmd_args)};
+  termios original_tty;
+  winsize ws;
+  VERIFY(tcgetattr(STDIN_FILENO, &original_tty) != -1, "Failed to get attributes for stdin");
+  VERIFY(ioctl(STDIN_FILENO, TIOCGWINSZ, &ws) >= 0, "Failed to get winsize of stdin");
+
+  auto fork_result = pty_fork(&original_tty, &ws);
+  // todo(simon): we're forking our already big Tracer process, just to tear it down and exec a new process
+  //  I'd much rather like a "stub" process to exec from, that gets handed to us by some "Fork server" thing,
+  //  but the logic for that is way more complex and I'm not really interested in solving that problem right now.
+  switch (fork_result.index()) {
+  case 0: // child
+  {
+    const auto [cmd, args] = args_list.get_command();
+    if (personality(ADDR_NO_RANDOMIZE) == -1) {
+      PANIC("Failed to set ADDR_NO_RANDOMIZE!");
+    }
+    raise(SIGSTOP);
+    if (execv(cmd, args) == -1) {
+      PANIC(fmt::format("EXECV Failed for {}", cmd));
+    }
+  }
+  default: {
+    const auto res = get<PtyParentResult>(fork_result);
+    add_target_set_current(res.pid, program, TargetSession::Launched);
+
+    for (;;) {
+      if (const auto ws = waitpid_block(res.pid); ws) {
+        const auto stat = ws->status;
+        if ((stat >> 8) == (SIGTRAP | (PTRACE_EVENT_EXEC << 8))) {
+          TaskWaitResult twr;
+          twr.ws = WaitStatus::Execed;
+          twr.waited_pid = res.pid;
+          get_current()->reopen_memfd();
+          get_current()->cache_registers(twr.waited_pid);
+          get_current()->read_auxv(twr);
+          dap->add_tty(res.fd);
+          break;
+        }
+      }
+      VERIFY(ptrace(PTRACE_CONT, res.pid, 0, 0) != -1, "Failed to continue passed our exec boundary");
+    }
+    break;
+  }
+  }
+}
+
+void
+Tracer::kill_all_targets() noexcept
+{
+  for (auto &&t : targets) {
+    switch (t->session_type()) {
+    case TargetSession::Launched:
+      t->terminate_gracefully();
+      break;
+    case TargetSession::Attached:
+      detach(std::move(t));
+      break;
+    }
+  }
+  targets.clear();
+}
+
+void
+Tracer::detach(std::unique_ptr<Target> &&target) noexcept
+{
+  // we have taken ownership of `target` in this "sink". Target will be destroyed (should be?)
+  target->detach();
 }

--- a/src/tracer.h
+++ b/src/tracer.h
@@ -65,6 +65,8 @@ public:
   void accept_command(ui::UICommand *cmd) noexcept;
   void execute_pending_commands() noexcept;
 
+  void launch(Path &&program, std::vector<std::string> &&prog_args) noexcept;
+
 private:
   std::vector<std::unique_ptr<Target>> targets;
   Target *current_target = nullptr;
@@ -74,4 +76,5 @@ private:
   std::queue<ui::UICommand *> command_queue;
   utils::Notifier::ReadEnd wait_pipe;
   utils::Notifier::ReadEnd io_thread_pipe;
+  bool already_launched;
 };

--- a/src/tracer.h
+++ b/src/tracer.h
@@ -7,6 +7,8 @@
 #include <cstdint>
 #include <nlohmann/json_fwd.hpp>
 #include <queue>
+#include <sys/ioctl.h>
+#include <termios.h>
 #include <unordered_map>
 #include <vector>
 
@@ -40,14 +42,16 @@ enum class AddObjectResult : u8
 class Tracer
 {
 public:
+  static termios original_tty;
+  static winsize ws;
   static Tracer *Instance;
   friend struct ui::UICommand;
-  Tracer(utils::Notifier::ReadEnd wait_pipe, utils::Notifier::ReadEnd io_thread_pipe) noexcept;
-  void add_target_set_current(pid_t task_leader, const Path &path) noexcept;
+  Tracer(utils::Notifier::ReadEnd io_thread_pipe, utils::NotifyManager *events_notifier) noexcept;
+  void add_target_set_current(pid_t task_leader, const Path &path, TargetSession session) noexcept;
   void load_and_process_objfile(pid_t target, const Path &objfile_path) noexcept;
   AddObjectResult mmap_objectfile(const Path &path) noexcept;
   void thread_exited(LWP lwp, int status) noexcept;
-  Target &get_target(pid_t pid) noexcept;
+  Target *get_target(pid_t pid) noexcept;
   Target *get_current() noexcept;
 
   /// Create & Initialize IO thread that deals with input/output between the tracee/tracer
@@ -56,6 +60,7 @@ public:
   void interrupt(LWP lwp) noexcept;
 
   bool wait_for_tracee_events() noexcept;
+  bool wait_for_tracee_events(Tid target) noexcept;
   void set_ui(ui::dap::DAP *dap) noexcept;
   void kill_ui() noexcept;
   void post_event(ui::UIResultPtr obj) noexcept;
@@ -64,8 +69,9 @@ public:
    * hang. */
   void accept_command(ui::UICommand *cmd) noexcept;
   void execute_pending_commands() noexcept;
-
   void launch(Path &&program, std::vector<std::string> &&prog_args) noexcept;
+  void kill_all_targets() noexcept;
+  void detach(std::unique_ptr<Target> &&target) noexcept;
 
 private:
   std::vector<std::unique_ptr<Target>> targets;
@@ -74,7 +80,7 @@ private:
   ui::dap::DAP *dap;
   SpinLock command_queue_lock;
   std::queue<ui::UICommand *> command_queue;
-  utils::Notifier::ReadEnd wait_pipe;
   utils::Notifier::ReadEnd io_thread_pipe;
   bool already_launched;
+  utils::NotifyManager *events_notifier;
 };

--- a/src/utils/base64.cpp
+++ b/src/utils/base64.cpp
@@ -1,4 +1,5 @@
 #include "base64.h"
+#include <cmath>
 
 namespace utils {
 
@@ -7,7 +8,10 @@ encode_base64(std::span<std::uint8_t> data) noexcept
 {
   std::string buffer;
   buffer.reserve(static_cast<size_t>((double)data.size() * 1.40));
-  for (auto i = 0ul; i < data.size(); i += 3) {
+  const auto chunks = std::floor((static_cast<float>(data.size()) / 3.0f));
+  const auto total = chunks * 3;
+  auto i = 0ul;
+  for (; i < total; i += 3) {
     const std::uint16_t s0 = data[i];
     const std::uint16_t s1 = data[i + 1];
     const std::uint16_t s2 = data[i + 2];
@@ -17,6 +21,11 @@ encode_base64(std::span<std::uint8_t> data) noexcept
     buffer.push_back(base64_lookup[(((s1 * 4) % 64) + (s2 / 64))]);
     buffer.push_back(lookup_byte4[data[i + 2]]);
   }
+  while (i < data.size()) {
+    buffer.push_back('=');
+    i++;
+  }
+
   return buffer;
 }
 } // namespace utils

--- a/src/utils/static_vector.h
+++ b/src/utils/static_vector.h
@@ -38,10 +38,11 @@ public:
     *(data + size) = t;
   }
 
-  T *
+  template <typename U = T>
+  U *
   data_ptr() noexcept
   {
-    return data;
+    return (U *)data;
   }
 
   std::span<T>

--- a/test/threads.cpp
+++ b/test/threads.cpp
@@ -10,6 +10,8 @@
 
 using ThreadPool = std::vector<std::thread>;
 
+static Foo *global_foo = new Foo{.a = 10000, .b = 20000, .c = 30000, .d = 40000};
+
 int
 main(int argc, const char **argv)
 {


### PR DESCRIPTION
Major refactor, but the key take aways is this;

Introduced a new key player in the multi threaded design; The [`AwaiterThread`](https://github.com/theIDinside/mdebug/compare/re-factor-main-app-threads?expand=1#diff-713e6a6c34be7b51182057ba1a42c6780b38114dc50f13efe651bfa142f0742aR1-R47) whose sole purpose is to `waitid` (notice, WAITID *not* WAITPID, because WAITPID does not allow us to leave the "awaitable task" in a "waitable state" after having read the wait status. Why that is, only the dark lords of the linux kernel knows) on tasks and report to the main Tracer thread that it can do a non-blocking (and consuming) `waitpid` on a `Target`'s task leader.

The DAP UI also has gained the ability to monitor multiple processes stdouts, by [adding new pseudo terminal fds](https://github.com/theIDinside/mdebug/compare/re-factor-main-app-threads?expand=1#diff-22f03f27a40b4b2ba280c9fe1c5ea4526d4cb82fa7f9472a3ce89d207f79694eR262-R283)

Added the [`NotifyManager`](https://github.com/theIDinside/mdebug/compare/re-factor-main-app-threads?expand=1#diff-77a8be6e63f02ce41a69119c1861d580662216a41fc0d9cad698919e417627adR1-R72) which essentially wraps all "observable sources"; so that the main `Tracer` thread can poll the manager and query for new events.

Added new DAP requests:
- Launch
- Disconnect
- Terminate

Fixed DAP request:
- ReadMemory; had a bug in the base64 encoding. 