### PR TITLE
Make RelocatedLteIterator "fully" noexcept

### DIFF
--- a/src/ptracestop_handlers.cpp
+++ b/src/ptracestop_handlers.cpp
@@ -62,23 +62,23 @@ LineStep::LineStep(StopHandler *handler, TaskInfo *task, int lines) noexcept
   auto tc = handler->tc;
   auto &callstack = tc->build_callframe_stack(task, CallStackRequest::partial(1));
   start_frame = callstack.frames[0];
-  auto obj = tc->find_obj_by_pc(start_frame.rip);
+  ObjectFile *obj = tc->find_obj_by_pc(start_frame.rip);
   auto src_infos = obj->get_source_infos(start_frame.rip);
-  auto found = false;
+  bool found = false;
   for (auto *src : src_infos) {
     auto ltopt = src->get_linetable();
     if (ltopt) {
       auto lt = *ltopt;
-      auto it = lt.find_by_pc(start_frame.rip);
-      if (it != std::end(lt)) {
-        auto lte = it.get();
+      const auto iter = lt.find_by_pc(start_frame.rip);
+      if (iter != std::end(lt)) {
+        const sym::dw::LineTableEntry lte = iter.get();
         if (lte.pc == start_frame.rip) {
           found = true;
           entry = lte;
           break;
         } else {
           found = true;
-          entry = (it - 1).get();
+          entry = (iter - 1).get();
           break;
         }
       }

--- a/src/symbolication/dwarf/lnp.cpp
+++ b/src/symbolication/dwarf/lnp.cpp
@@ -325,48 +325,48 @@ RelocatedLteIterator::get() const noexcept
 }
 
 RelocatedLteIterator
-RelocatedLteIterator::operator+(difference_type diff)
+RelocatedLteIterator::operator+(difference_type diff) const noexcept
 {
   auto copy = *this;
   return copy += diff;
 }
 
 RelocatedLteIterator
-RelocatedLteIterator::operator-(difference_type diff)
+RelocatedLteIterator::operator-(difference_type diff) const noexcept
 {
   auto copy = *this;
   return copy -= diff;
 }
 
 RelocatedLteIterator::difference_type
-RelocatedLteIterator::operator-(RelocatedLteIterator other)
+RelocatedLteIterator::operator-(RelocatedLteIterator other) const noexcept
 {
   return it - other.it;
 }
 
 RelocatedLteIterator &
-RelocatedLteIterator::operator+=(difference_type diff)
+RelocatedLteIterator::operator+=(difference_type diff) noexcept
 {
   it += diff;
   return *this;
 }
 
 RelocatedLteIterator &
-RelocatedLteIterator::operator-=(difference_type diff)
+RelocatedLteIterator::operator-=(difference_type diff) noexcept
 {
   it -= diff;
   return *this;
 }
 
 RelocatedLteIterator &
-RelocatedLteIterator::operator++()
+RelocatedLteIterator::operator++() noexcept
 {
   ++it;
   return *this;
 }
 
 RelocatedLteIterator
-RelocatedLteIterator::operator++(int)
+RelocatedLteIterator::operator++(int) noexcept
 {
   auto copy = *this;
   ++copy.it;
@@ -374,14 +374,14 @@ RelocatedLteIterator::operator++(int)
 }
 
 RelocatedLteIterator &
-RelocatedLteIterator::operator--()
+RelocatedLteIterator::operator--() noexcept
 {
   --it;
   return *this;
 }
 
 RelocatedLteIterator
-RelocatedLteIterator::operator--(int)
+RelocatedLteIterator::operator--(int) noexcept
 {
   auto copy = *this;
   --copy.it;

--- a/src/symbolication/dwarf/lnp.h
+++ b/src/symbolication/dwarf/lnp.h
@@ -87,16 +87,16 @@ public:
   LineTableEntry operator*();
   LineTableEntry get() const noexcept;
 
-  RelocatedLteIterator operator+(difference_type diff);
-  RelocatedLteIterator operator-(difference_type diff);
-  difference_type operator-(RelocatedLteIterator diff);
+  RelocatedLteIterator operator+(difference_type diff) const noexcept;
+  RelocatedLteIterator operator-(difference_type diff) const noexcept;
+  difference_type operator-(RelocatedLteIterator diff) const noexcept;
 
-  RelocatedLteIterator &operator+=(difference_type diff);
-  RelocatedLteIterator &operator-=(difference_type diff);
-  RelocatedLteIterator &operator++();
-  RelocatedLteIterator operator++(int);
-  RelocatedLteIterator &operator--();
-  RelocatedLteIterator operator--(int);
+  RelocatedLteIterator &operator+=(difference_type diff) noexcept;
+  RelocatedLteIterator &operator-=(difference_type diff) noexcept;
+  RelocatedLteIterator &operator++() noexcept;
+  RelocatedLteIterator operator++(int) noexcept;
+  RelocatedLteIterator &operator--() noexcept;
+  RelocatedLteIterator operator--(int) noexcept;
 
   friend bool operator==(const RelocatedLteIterator &l, const RelocatedLteIterator &r);
   friend bool operator!=(const RelocatedLteIterator &l, const RelocatedLteIterator &r);


### PR DESCRIPTION
Start making code a little bit more legible by not "autoing everything" and start being more thoughtful about it.

For instance, in the example below; saying `sym::dw::LineTableEntry lte`  makes it easier to read than just `auto lte` - even though I personally know `lte` == LineTableEntry.

Also made additional methods on `RelocatedLteIterator`, `const` and `noexcept` 