### PR TITLE
Command local arena allocators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,8 @@ set(MIDAS_SOURCES
   src/events/event.h
   # lib
   src/lib/lockguard.h
+  src/lib/arena_allocator.cpp
+  src/lib/arena_allocator.h
   # symbolication
   src/symbolication/block.cpp
   src/symbolication/block.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,7 +174,7 @@ target_include_directories(zydis PRIVATE ./dependencies/zydis)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(COMMON_FLAGS "-msse2 -D__MMX__ -D__SSE__ -D__SSE2__ -march=native -mavx -mavx2")
-set(MIDAS_DEBUG_FLAGS "-g3 -O0 -Wall -Wextra -fpermissive")
+set(MIDAS_DEBUG_FLAGS "-g3 -O0 -fpermissive")
 set(MIDAS_TEST_FLAGS "${MIDAS_DEBUG_FLAGS}")
 
 if(USE_DWARF5)

--- a/src/common.h
+++ b/src/common.h
@@ -130,6 +130,18 @@ std::string_view syscall_name(unsigned long long syscall_number);
     MIDAS_UNREACHABLE                                                                                             \
   }
 
+#define IGNORE_WARN(...) (void)sizeof...(__VA_ARGS__);
+
+template <typename... Args>
+void
+IgnoreArgs(const Args&...)
+{
+}
+
+#define TODO_IGNORE_WARN(message, ...)                                                                            \
+  IgnoreArgs(__VA_ARGS__);                                                                                        \
+  TODO(message);
+
 #define TODO_FMT(fmt_str, ...)                                                                                    \
   {                                                                                                               \
     auto loc = std::source_location::current();                                                                   \

--- a/src/interface/dap/commands.cpp
+++ b/src/interface/dap/commands.cpp
@@ -62,7 +62,7 @@ ErrorResponse::ErrorResponse(std::string_view command, ui::UICommandPtr cmd,
 }
 
 std::string
-ErrorResponse::serialize(int seq) const noexcept
+ErrorResponse::Serialize(int seq) const noexcept
 {
   if (short_message && message) {
     return fmt::format(
@@ -83,7 +83,7 @@ ErrorResponse::serialize(int seq) const noexcept
 }
 
 std::string
-PauseResponse::serialize(int seq) const noexcept
+PauseResponse::Serialize(int seq) const noexcept
 {
   if (success) {
     return fmt::format(R"({{"seq":{},"request_seq":{},"type":"response","success":true,"command":"pause"}})", seq,
@@ -96,7 +96,7 @@ PauseResponse::serialize(int seq) const noexcept
 }
 
 UIResultPtr
-Pause::execute() noexcept
+Pause::Execute() noexcept
 {
   auto target = dap_client->supervisor();
   auto task = target->GetTaskByTid(pauseArgs.threadId);
@@ -108,7 +108,7 @@ Pause::execute() noexcept
 }
 
 std::string
-ReverseContinueResponse::serialize(int seq) const noexcept
+ReverseContinueResponse::Serialize(int seq) const noexcept
 {
   if (success) {
     return fmt::format(
@@ -124,7 +124,7 @@ ReverseContinueResponse::serialize(int seq) const noexcept
 ReverseContinue::ReverseContinue(u64 seq, int thread_id) noexcept : UICommand(seq), thread_id(thread_id) {}
 
 UIResultPtr
-ReverseContinue::execute() noexcept
+ReverseContinue::Execute() noexcept
 {
   auto res = new ReverseContinueResponse{true, this};
   auto target = dap_client->supervisor();
@@ -134,7 +134,7 @@ ReverseContinue::execute() noexcept
 }
 
 std::string
-ContinueResponse::serialize(int seq) const noexcept
+ContinueResponse::Serialize(int seq) const noexcept
 {
 
   if (success) {
@@ -149,7 +149,7 @@ ContinueResponse::serialize(int seq) const noexcept
 }
 
 UIResultPtr
-Continue::execute() noexcept
+Continue::Execute() noexcept
 {
   auto res = new ContinueResponse{true, this};
   res->continue_all = continue_all;
@@ -179,7 +179,7 @@ Continue::execute() noexcept
 }
 
 std::string
-NextResponse::serialize(int seq) const noexcept
+NextResponse::Serialize(int seq) const noexcept
 {
   if (success) {
     return fmt::format(R"({{"seq":{},"request_seq":{},"type":"response","success":true,"command":"next"}})", seq,
@@ -192,7 +192,7 @@ NextResponse::serialize(int seq) const noexcept
 }
 
 UIResultPtr
-Next::execute() noexcept
+Next::Execute() noexcept
 {
   auto target = dap_client->supervisor();
   auto task = target->GetTaskByTid(thread_id);
@@ -216,7 +216,7 @@ Next::execute() noexcept
 }
 
 std::string
-StepInResponse::serialize(int seq) const noexcept
+StepInResponse::Serialize(int seq) const noexcept
 {
   if (success) {
     return fmt::format(R"({{"seq":{},"request_seq":{},"type":"response","success":true,"command":"stepIn"}})", seq,
@@ -229,7 +229,7 @@ StepInResponse::serialize(int seq) const noexcept
 }
 
 UIResultPtr
-StepIn::execute() noexcept
+StepIn::Execute() noexcept
 {
   auto target = dap_client->supervisor();
   auto task = target->GetTaskByTid(thread_id);
@@ -252,7 +252,7 @@ StepIn::execute() noexcept
 }
 
 std::string
-StepOutResponse::serialize(int seq) const noexcept
+StepOutResponse::Serialize(int seq) const noexcept
 {
   if (success) {
     return fmt::format(R"({{"seq":{},"request_seq":{},"type":"response","success":true,"command":"stepOut"}})",
@@ -265,7 +265,7 @@ StepOutResponse::serialize(int seq) const noexcept
 }
 
 UIResultPtr
-StepOut::execute() noexcept
+StepOut::Execute() noexcept
 {
   auto target = dap_client->supervisor();
   auto task = target->GetTaskByTid(thread_id);
@@ -294,7 +294,7 @@ SetBreakpointsResponse::SetBreakpointsResponse(bool success, ui::UICommandPtr cm
 }
 
 std::string
-SetBreakpointsResponse::serialize(int seq) const noexcept
+SetBreakpointsResponse::Serialize(int seq) const noexcept
 {
   std::vector<std::string> serialized_bkpts{};
   serialized_bkpts.reserve(breakpoints.size());
@@ -333,7 +333,7 @@ SetBreakpoints::SetBreakpoints(std::uint64_t seq, nlohmann::json &&arguments) no
 }
 
 UIResultPtr
-SetBreakpoints::execute() noexcept
+SetBreakpoints::Execute() noexcept
 {
   auto res = new SetBreakpointsResponse{true, this, BreakpointRequestKind::source};
   auto target = dap_client->supervisor();
@@ -372,7 +372,7 @@ SetExceptionBreakpoints::SetExceptionBreakpoints(std::uint64_t sequence, nlohman
 }
 
 UIResultPtr
-SetExceptionBreakpoints::execute() noexcept
+SetExceptionBreakpoints::Execute() noexcept
 {
   DBGLOG(core, "exception breakpoints not yet implemented");
   auto res = new SetBreakpointsResponse{true, this, BreakpointRequestKind::exception};
@@ -387,7 +387,7 @@ SetInstructionBreakpoints::SetInstructionBreakpoints(std::uint64_t seq, nlohmann
 }
 
 UIResultPtr
-SetInstructionBreakpoints::execute() noexcept
+SetInstructionBreakpoints::Execute() noexcept
 {
   using BP = ui::dap::Breakpoint;
   Set<InstructionBreakpointSpec> bps{};
@@ -422,7 +422,7 @@ SetFunctionBreakpoints::SetFunctionBreakpoints(std::uint64_t seq, nlohmann::json
 }
 
 UIResultPtr
-SetFunctionBreakpoints::execute() noexcept
+SetFunctionBreakpoints::Execute() noexcept
 {
   using BP = ui::dap::Breakpoint;
   Set<FunctionBreakpointSpec> bkpts{};
@@ -452,7 +452,7 @@ SetFunctionBreakpoints::execute() noexcept
 }
 
 std::string
-WriteMemoryResponse::serialize(int seq) const noexcept
+WriteMemoryResponse::Serialize(int seq) const noexcept
 {
   return fmt::format(
     R"({{"seq":{},"request_seq":{},"type":"response","success":{},"command":"writeMemory","body":{{"bytesWritten":{}}}}})",
@@ -465,7 +465,7 @@ WriteMemory::WriteMemory(u64 seq, std::optional<AddrPtr> address, int offset, st
 }
 
 UIResultPtr
-WriteMemory::execute() noexcept
+WriteMemory::Execute() noexcept
 {
   auto supervisor = dap_client->supervisor();
   auto response = new WriteMemoryResponse{false, this};
@@ -482,7 +482,7 @@ WriteMemory::execute() noexcept
 }
 
 std::string
-ReadMemoryResponse::serialize(int seq) const noexcept
+ReadMemoryResponse::Serialize(int seq) const noexcept
 {
   if (success) {
     return fmt::format(
@@ -499,7 +499,7 @@ ReadMemory::ReadMemory(std::uint64_t seq, std::optional<AddrPtr> address, int of
 }
 
 UIResultPtr
-ReadMemory::execute() noexcept
+ReadMemory::Execute() noexcept
 {
   if (address) {
     auto sv = dap_client->supervisor()->ReadToVector(*address, bytes);
@@ -515,7 +515,7 @@ ReadMemory::execute() noexcept
 }
 
 std::string
-ConfigurationDoneResponse::serialize(int seq) const noexcept
+ConfigurationDoneResponse::Serialize(int seq) const noexcept
 {
   return fmt::format(
     R"({{"seq":{},"request_seq":{},"type":"response","success":true,"command":"configurationDone"}})", seq,
@@ -523,7 +523,7 @@ ConfigurationDoneResponse::serialize(int seq) const noexcept
 }
 
 UIResultPtr
-ConfigurationDone::execute() noexcept
+ConfigurationDone::Execute() noexcept
 {
   Tracer::Instance->config_done(dap_client);
   switch (dap_client->supervisor()->GetSessionType()) {
@@ -543,7 +543,7 @@ Initialize::Initialize(std::uint64_t seq, nlohmann::json &&arguments) noexcept
 }
 
 UIResultPtr
-Initialize::execute() noexcept
+Initialize::Execute() noexcept
 {
   bool RRSession = false;
   if (args.contains("RRSession")) {
@@ -553,7 +553,7 @@ Initialize::execute() noexcept
 }
 
 std::string
-DisconnectResponse::serialize(int seq) const noexcept
+DisconnectResponse::Serialize(int seq) const noexcept
 {
   return fmt::format(R"({{"seq":{},"request_seq":{},"type":"response","success":true,"command":"disconnect"}})",
                      seq, request_seq);
@@ -564,7 +564,7 @@ Disconnect::Disconnect(std::uint64_t seq, bool restart, bool terminate_debuggee,
 {
 }
 UIResultPtr
-Disconnect::execute() noexcept
+Disconnect::Execute() noexcept
 {
   const auto ok = dap_client->supervisor()->GetInterface().DoDisconnect(true);
   if (ok) {
@@ -582,7 +582,7 @@ InitializeResponse::InitializeResponse(bool rrsession, bool ok, UICommandPtr cmd
 }
 
 std::string
-InitializeResponse::serialize(int) const noexcept
+InitializeResponse::Serialize(int) const noexcept
 {
   // "this _must_ be 1, the first response"
 
@@ -640,12 +640,12 @@ InitializeResponse::serialize(int) const noexcept
     request_seq, cfg_body.dump());
 
   client->write(payload);
-  client->write(InitializedEvent{}.serialize(0));
+  client->write(InitializedEvent{}.Serialize(0));
   return "";
 }
 
 std::string
-LaunchResponse::serialize(int seq) const noexcept
+LaunchResponse::Serialize(int seq) const noexcept
 {
   return fmt::format(R"({{"seq":{},"request_seq":{},"type":"response","success":true,"command":"launch"}})", seq,
                      request_seq);
@@ -658,14 +658,14 @@ Launch::Launch(std::uint64_t seq, bool stopOnEntry, Path &&program,
 }
 
 UIResultPtr
-Launch::execute() noexcept
+Launch::Execute() noexcept
 {
   Tracer::Instance->launch(dap_client, stopOnEntry, std::move(program), std::move(program_args));
   return new LaunchResponse{true, this};
 }
 
 std::string
-AttachResponse::serialize(int seq) const noexcept
+AttachResponse::Serialize(int seq) const noexcept
 {
   return fmt::format(R"({{"seq":{},"request_seq":{},"type":"response","success":true,"command":"attach"}})", seq,
                      request_seq);
@@ -674,21 +674,21 @@ AttachResponse::serialize(int seq) const noexcept
 Attach::Attach(std::uint64_t seq, AttachArgs &&args) noexcept : UICommand(seq), attachArgs(std::move(args)) {}
 
 UIResultPtr
-Attach::execute() noexcept
+Attach::Execute() noexcept
 {
   const auto res = Tracer::Instance->attach(attachArgs);
   return new AttachResponse{res, this};
 }
 
 std::string
-TerminateResponse::serialize(int seq) const noexcept
+TerminateResponse::Serialize(int seq) const noexcept
 {
   return fmt::format(R"({{"seq":{},"request_seq":{},"type":"response","success":true,"command":"terminate"}})",
                      seq, request_seq);
 }
 
 UIResultPtr
-Terminate::execute() noexcept
+Terminate::Execute() noexcept
 {
   const auto ok = dap_client->supervisor()->GetInterface().DoDisconnect(true);
   if (ok) {
@@ -701,7 +701,7 @@ Terminate::execute() noexcept
 }
 
 std::string
-ThreadsResponse::serialize(int seq) const noexcept
+ThreadsResponse::Serialize(int seq) const noexcept
 {
   return fmt::format(
     R"({{"seq":{},"request_seq":{},"type":"response","success":true,"command":"threads","body":{{"threads":[{}]}}}})",
@@ -709,7 +709,7 @@ ThreadsResponse::serialize(int seq) const noexcept
 }
 
 UIResultPtr
-Threads::execute() noexcept
+Threads::Execute() noexcept
 {
   // todo(simon): right now, we only support 1 process, but theoretically the current design
   // allows for more; it would require some work to get the DAP protocol to play nicely though.
@@ -755,7 +755,7 @@ StackTraceResponse::StackTraceResponse(bool success, StackTrace *cmd,
 }
 
 std::string
-StackTraceResponse::serialize(int seq) const noexcept
+StackTraceResponse::Serialize(int seq) const noexcept
 {
   return fmt::format(
     R"({{"seq":{},"request_seq":{},"type":"response","success":true,"command":"stackTrace","body":{{"stackFrames":[{}]}}}})",
@@ -773,7 +773,7 @@ is_debug_build()
 }
 
 UIResultPtr
-StackTrace::execute() noexcept
+StackTrace::Execute() noexcept
 {
   // todo(simon): multiprocessing needs additional work, since DAP does not support it natively.
   auto target = dap_client->supervisor();
@@ -812,7 +812,7 @@ StackTrace::execute() noexcept
 Scopes::Scopes(std::uint64_t seq, int frameId) noexcept : UICommand(seq), frameId(frameId) {}
 
 std::string
-ScopesResponse::serialize(int seq) const noexcept
+ScopesResponse::Serialize(int seq) const noexcept
 {
   return fmt::format(
     R"({{"seq":{},"request_seq":{},"type":"response","success":true,"command":"scopes","body":{{"scopes":[{}]}}}})",
@@ -825,7 +825,7 @@ ScopesResponse::ScopesResponse(bool success, Scopes *cmd, std::array<Scope, 3> s
 }
 
 UIResultPtr
-Scopes::execute() noexcept
+Scopes::Execute() noexcept
 {
   auto ctx = Tracer::Instance->var_context(frameId);
   if (!ctx.valid_context() || ctx.type != ContextType::Frame) {
@@ -847,7 +847,7 @@ Disassemble::Disassemble(std::uint64_t seq, std::optional<AddrPtr> address, int 
 }
 
 UIResultPtr
-Disassemble::execute() noexcept
+Disassemble::Execute() noexcept
 {
   if (address) {
     auto res = new DisassembleResponse{true, this};
@@ -888,7 +888,7 @@ Disassemble::execute() noexcept
 }
 
 std::string
-DisassembleResponse::serialize(int seq) const noexcept
+DisassembleResponse::Serialize(int seq) const noexcept
 {
   return fmt::format(
     R"({{"seq":{},"request_seq":{},"type":"response","success":true,"command":"disassemble","body":{{"instructions":[{}]}}}})",
@@ -908,7 +908,7 @@ Evaluate::Evaluate(u64 seq, std::string &&expression, std::optional<int> frameId
 }
 
 UIResultPtr
-Evaluate::execute() noexcept
+Evaluate::Execute() noexcept
 {
   switch (context) {
   case EvaluationContext::Watch:
@@ -969,7 +969,7 @@ EvaluateResponse::EvaluateResponse(bool success, Evaluate *cmd, std::optional<in
 }
 
 std::string
-EvaluateResponse::serialize(int seq) const noexcept
+EvaluateResponse::Serialize(int seq) const noexcept
 {
   if (success) {
     return fmt::format(
@@ -995,7 +995,7 @@ Variables::error(std::string &&msg) noexcept
 }
 
 UIResultPtr
-Variables::execute() noexcept
+Variables::Execute() noexcept
 {
   auto context = Tracer::Instance->var_context(var_ref);
   if (!context.valid_context()) {
@@ -1041,7 +1041,7 @@ VariablesResponse::VariablesResponse(bool success, Variables *cmd, std::vector<V
 }
 
 std::string
-VariablesResponse::serialize(int seq) const noexcept
+VariablesResponse::Serialize(int seq) const noexcept
 {
   if (variables.empty()) {
     return fmt::format(
@@ -1090,7 +1090,7 @@ InvalidArgs::InvalidArgs(std::uint64_t seq, std::string_view command, MissingOrI
 }
 
 UIResultPtr
-InvalidArgs::execute() noexcept
+InvalidArgs::Execute() noexcept
 {
   return new InvalidArgsResponse{command, std::move(missing_arguments)};
 }
@@ -1101,7 +1101,7 @@ InvalidArgsResponse::InvalidArgsResponse(std::string_view command, MissingOrInva
 }
 
 std::string
-InvalidArgsResponse::serialize(int seq) const noexcept
+InvalidArgsResponse::Serialize(int seq) const noexcept
 {
   std::vector<std::string_view> missing{};
   std::vector<const InvalidArg *> parsed_and_invalid{};

--- a/src/interface/dap/commands.h
+++ b/src/interface/dap/commands.h
@@ -205,7 +205,7 @@ struct ErrorResponse final : ui::UIResult
   ErrorResponse(std::string_view command, ui::UICommandPtr cmd, std::optional<std::string> &&short_message,
                 std::optional<Message> &&message) noexcept;
   ~ErrorResponse() noexcept override = default;
-  std::string serialize(int seq) const noexcept final;
+  std::string Serialize(int seq) const noexcept final;
 
   std::string_view command;
   std::optional<std::string> short_message;
@@ -217,7 +217,7 @@ struct ReverseContinueResponse final : ui::UIResult
   CTOR(ReverseContinueResponse);
   ~ReverseContinueResponse() noexcept override = default;
   bool continue_all;
-  std::string serialize(int seq) const noexcept final;
+  std::string Serialize(int seq) const noexcept final;
 };
 
 /** ReverseContinue under RR is *always* "continue all"*/
@@ -226,7 +226,7 @@ struct ReverseContinue final : ui::UICommand
   ReverseContinue(u64 seq, int thread_id) noexcept;
   ~ReverseContinue() noexcept override = default;
   int thread_id;
-  UIResultPtr execute() noexcept final;
+  UIResultPtr Execute() noexcept final;
 
   DEFINE_NAME("reverseContinue");
   RequiredArguments({"threadId"sv});
@@ -238,7 +238,7 @@ struct ContinueResponse final : ui::UIResult
   CTOR(ContinueResponse);
   ~ContinueResponse() noexcept override = default;
   bool continue_all;
-  std::string serialize(int seq) const noexcept final;
+  std::string Serialize(int seq) const noexcept final;
 };
 
 struct Continue final : public ui::UICommand
@@ -248,7 +248,7 @@ struct Continue final : public ui::UICommand
 
   Continue(u64 seq, int tid, bool all) noexcept : UICommand(seq), thread_id(tid), continue_all(all) {}
   ~Continue() override = default;
-  UIResultPtr execute() noexcept final;
+  UIResultPtr Execute() noexcept final;
 
   DEFINE_NAME("continue");
   RequiredArguments({"threadId"sv});
@@ -259,7 +259,7 @@ struct PauseResponse final : ui::UIResult
 {
   CTOR(PauseResponse);
   ~PauseResponse() noexcept override = default;
-  std::string serialize(int seq) const noexcept final;
+  std::string Serialize(int seq) const noexcept final;
 };
 
 struct Pause final : public ui::UICommand
@@ -271,7 +271,7 @@ struct Pause final : public ui::UICommand
 
   Pause(u64 seq, Args args) noexcept : UICommand(seq), pauseArgs(args) {}
   ~Pause() override = default;
-  UIResultPtr execute() noexcept final;
+  UIResultPtr Execute() noexcept final;
 
   Args pauseArgs;
   DEFINE_NAME("pause");
@@ -290,7 +290,7 @@ struct NextResponse final : ui::UIResult
 {
   CTOR(NextResponse);
   ~NextResponse() noexcept override = default;
-  std::string serialize(int seq) const noexcept final;
+  std::string Serialize(int seq) const noexcept final;
 };
 
 struct Next final : public ui::UICommand
@@ -304,7 +304,7 @@ struct Next final : public ui::UICommand
   {
   }
   ~Next() override = default;
-  UIResultPtr execute() noexcept final;
+  UIResultPtr Execute() noexcept final;
   DEFINE_NAME("next");
   RequiredArguments({"threadId"sv});
   DefineArgTypes({"threadId", FieldType::Int});
@@ -314,7 +314,7 @@ struct StepInResponse final : ui::UIResult
 {
   CTOR(StepInResponse);
   ~StepInResponse() noexcept override = default;
-  std::string serialize(int seq) const noexcept final;
+  std::string Serialize(int seq) const noexcept final;
 };
 
 struct StepIn final : public ui::UICommand
@@ -329,7 +329,7 @@ struct StepIn final : public ui::UICommand
   }
 
   ~StepIn() noexcept final = default;
-  UIResultPtr execute() noexcept final;
+  UIResultPtr Execute() noexcept final;
   DEFINE_NAME("stepIn");
   RequiredArguments({"threadId"});
   DefineArgTypes({"threadId", FieldType::Int});
@@ -339,7 +339,7 @@ struct StepOutResponse final : ui::UIResult
 {
   CTOR(StepOutResponse);
   ~StepOutResponse() noexcept override = default;
-  std::string serialize(int seq) const noexcept final;
+  std::string Serialize(int seq) const noexcept final;
 };
 
 struct StepOut final : public ui::UICommand
@@ -349,7 +349,7 @@ struct StepOut final : public ui::UICommand
 
   StepOut(u64 seq, int tid, bool all) noexcept : UICommand(seq), thread_id(tid), continue_all(all) {}
   ~StepOut() override = default;
-  UIResultPtr execute() noexcept final;
+  UIResultPtr Execute() noexcept final;
   DEFINE_NAME("stepOut");
   RequiredArguments({"threadId"sv});
   DefineArgTypes({"threadId", FieldType::Int});
@@ -363,7 +363,7 @@ struct SetBreakpointsResponse final : ui::UIResult
   BreakpointRequestKind type;
   std::vector<ui::dap::Breakpoint> breakpoints;
   ~SetBreakpointsResponse() noexcept override = default;
-  std::string serialize(int seq) const noexcept final;
+  std::string Serialize(int seq) const noexcept final;
 };
 
 struct SetBreakpoints final : public ui::UICommand
@@ -371,7 +371,7 @@ struct SetBreakpoints final : public ui::UICommand
   SetBreakpoints(u64 seq, nlohmann::json &&arguments) noexcept;
   ~SetBreakpoints() override = default;
   nlohmann::json args;
-  UIResultPtr execute() noexcept final;
+  UIResultPtr Execute() noexcept final;
   DEFINE_NAME("setBreakpoints");
   RequiredArguments({"source"sv});
 };
@@ -380,7 +380,7 @@ struct SetExceptionBreakpoints final : public ui::UICommand
 {
   SetExceptionBreakpoints(u64 sequence, nlohmann::json &&args) noexcept;
   ~SetExceptionBreakpoints() override = default;
-  UIResultPtr execute() noexcept final;
+  UIResultPtr Execute() noexcept final;
 
   Immutable<nlohmann::json> args;
 
@@ -394,7 +394,7 @@ struct SetInstructionBreakpoints final : public ui::UICommand
   SetInstructionBreakpoints(u64 seq, nlohmann::json &&arguments) noexcept;
   ~SetInstructionBreakpoints() override = default;
   nlohmann::json args;
-  UIResultPtr execute() noexcept final;
+  UIResultPtr Execute() noexcept final;
   DEFINE_NAME("setInstructionBreakpoints");
   RequiredArguments({"breakpoints"sv});
 };
@@ -404,7 +404,7 @@ struct SetFunctionBreakpoints final : public ui::UICommand
   SetFunctionBreakpoints(u64 seq, nlohmann::json &&arguments) noexcept;
   ~SetFunctionBreakpoints() override = default;
   nlohmann::json args;
-  UIResultPtr execute() noexcept final;
+  UIResultPtr Execute() noexcept final;
   DEFINE_NAME("setFunctionBreakpoints");
   RequiredArguments({"breakpoints"sv});
 };
@@ -413,7 +413,7 @@ struct WriteMemoryResponse final : public ui::UIResult
 {
   CTOR(WriteMemoryResponse);
   ~WriteMemoryResponse() noexcept override = default;
-  std::string serialize(int seq) const noexcept final;
+  std::string Serialize(int seq) const noexcept final;
   u64 bytes_written;
 };
 
@@ -421,7 +421,7 @@ struct WriteMemory final : public ui::UICommand
 {
   WriteMemory(u64 seq, std::optional<AddrPtr> address, int offset, std::vector<u8> &&bytes) noexcept;
   ~WriteMemory() override = default;
-  UIResultPtr execute() noexcept final;
+  UIResultPtr Execute() noexcept final;
 
   std::optional<AddrPtr> address;
   int offset;
@@ -436,7 +436,7 @@ struct ReadMemoryResponse final : public ui::UIResult
 {
   CTOR(ReadMemoryResponse);
   ~ReadMemoryResponse() noexcept override = default;
-  std::string serialize(int seq) const noexcept final;
+  std::string Serialize(int seq) const noexcept final;
   AddrPtr first_readable_address;
   u64 unreadable_bytes;
   std::string data_base64;
@@ -446,7 +446,7 @@ struct ReadMemory final : public ui::UICommand
 {
   ReadMemory(u64 seq, std::optional<AddrPtr> address, int offset, u64 bytes) noexcept;
   ~ReadMemory() override = default;
-  UIResultPtr execute() noexcept final;
+  UIResultPtr Execute() noexcept final;
 
   std::optional<AddrPtr> address;
   int offset;
@@ -461,14 +461,14 @@ struct ConfigurationDoneResponse final : public ui::UIResult
 {
   CTOR(ConfigurationDoneResponse);
   ~ConfigurationDoneResponse() noexcept override = default;
-  std::string serialize(int seq) const noexcept final;
+  std::string Serialize(int seq) const noexcept final;
 };
 
 struct ConfigurationDone final : public ui::UICommand
 {
   ConfigurationDone(u64 seq) noexcept : UICommand(seq) {}
   ~ConfigurationDone() override = default;
-  UIResultPtr execute() noexcept final;
+  UIResultPtr Execute() noexcept final;
 
   DEFINE_NAME("configurationDone");
   NoRequiredArgs();
@@ -479,7 +479,7 @@ struct InitializeResponse final : public ui::UIResult
   CTOR(InitializeResponse);
   InitializeResponse(bool rrsession, bool ok, UICommandPtr cmd) noexcept;
   ~InitializeResponse() noexcept override = default;
-  std::string serialize(int seq) const noexcept final;
+  std::string Serialize(int seq) const noexcept final;
 
   bool RRSession;
 };
@@ -488,7 +488,7 @@ struct Initialize final : public ui::UICommand
 {
   Initialize(u64 seq, nlohmann::json &&arguments) noexcept;
   ~Initialize() override = default;
-  UIResultPtr execute() noexcept final;
+  UIResultPtr Execute() noexcept final;
   nlohmann::json args;
   DEFINE_NAME("initialize");
   NoRequiredArgs();
@@ -498,14 +498,14 @@ struct DisconnectResponse final : public UIResult
 {
   CTOR(DisconnectResponse);
   ~DisconnectResponse() noexcept override = default;
-  std::string serialize(int seq) const noexcept final;
+  std::string Serialize(int seq) const noexcept final;
 };
 
 struct Disconnect final : public UICommand
 {
   Disconnect(u64 seq, bool restart, bool terminate_debuggee, bool suspend_debuggee) noexcept;
   ~Disconnect() override = default;
-  UIResultPtr execute() noexcept final;
+  UIResultPtr Execute() noexcept final;
   bool restart, terminate_tracee, suspend_tracee;
   DEFINE_NAME("disconnect");
   NoRequiredArgs();
@@ -515,14 +515,14 @@ struct LaunchResponse final : public UIResult
 {
   CTOR(LaunchResponse);
   ~LaunchResponse() noexcept override = default;
-  std::string serialize(int seq) const noexcept final;
+  std::string Serialize(int seq) const noexcept final;
 };
 
 struct Launch final : public UICommand
 {
   Launch(u64 seq, bool stopAtEntry, Path &&program, std::vector<std::string> &&program_args) noexcept;
   ~Launch() override = default;
-  UIResultPtr execute() noexcept final;
+  UIResultPtr Execute() noexcept final;
   bool stopOnEntry;
   Path program;
   std::vector<std::string> program_args;
@@ -535,14 +535,14 @@ struct AttachResponse final : public UIResult
 {
   CTOR(AttachResponse);
   ~AttachResponse() noexcept override = default;
-  std::string serialize(int seq) const noexcept final;
+  std::string Serialize(int seq) const noexcept final;
 };
 
 struct Attach final : public UICommand
 {
   Attach(u64 seq, AttachArgs &&args) noexcept;
   ~Attach() override = default;
-  UIResultPtr execute() noexcept final;
+  UIResultPtr Execute() noexcept final;
 
   AttachArgs attachArgs;
   DEFINE_NAME("attach");
@@ -581,14 +581,14 @@ struct TerminateResponse final : public UIResult
 {
   CTOR(TerminateResponse);
   ~TerminateResponse() noexcept override = default;
-  std::string serialize(int seq) const noexcept final;
+  std::string Serialize(int seq) const noexcept final;
 };
 
 struct Terminate final : public UICommand
 {
   Terminate(u64 seq) noexcept : UICommand(seq) {}
   ~Terminate() override = default;
-  UIResultPtr execute() noexcept final;
+  UIResultPtr Execute() noexcept final;
   DEFINE_NAME("terminate");
   NoRequiredArgs();
 };
@@ -597,7 +597,7 @@ struct ThreadsResponse final : public UIResult
 {
   CTOR(ThreadsResponse);
   ~ThreadsResponse() noexcept override = default;
-  std::string serialize(int seq) const noexcept final;
+  std::string Serialize(int seq) const noexcept final;
   std::vector<Thread> threads;
 };
 
@@ -605,7 +605,7 @@ struct Threads final : public UICommand
 {
   Threads(u64 seq) noexcept : UICommand(seq) {}
   ~Threads() override = default;
-  UIResultPtr execute() noexcept final;
+  UIResultPtr Execute() noexcept final;
   DEFINE_NAME("threads");
   NoRequiredArgs();
 };
@@ -615,7 +615,7 @@ struct StackTrace final : public UICommand
   StackTrace(u64 seq, int threadId, std::optional<int> startFrame, std::optional<int> levels,
              std::optional<StackTraceFormat> format) noexcept;
   ~StackTrace() override = default;
-  UIResultPtr execute() noexcept final;
+  UIResultPtr Execute() noexcept final;
   int threadId;
   std::optional<int> startFrame;
   std::optional<int> levels;
@@ -630,7 +630,7 @@ struct StackTraceResponse final : public UIResult
   CTOR(StackTraceResponse);
   StackTraceResponse(bool success, StackTrace *cmd, std::vector<StackFrame> &&stack_frames) noexcept;
   ~StackTraceResponse() noexcept override = default;
-  std::string serialize(int seq) const noexcept final;
+  std::string Serialize(int seq) const noexcept final;
   std::vector<StackFrame> stack_frames;
 };
 
@@ -638,7 +638,7 @@ struct Scopes final : public UICommand
 {
   Scopes(u64 seq, int frameId) noexcept;
   ~Scopes() override = default;
-  UIResultPtr execute() noexcept final;
+  UIResultPtr Execute() noexcept final;
   int frameId;
   DEFINE_NAME("scopes");
   RequiredArguments({"frameId"sv});
@@ -649,7 +649,7 @@ struct ScopesResponse final : public UIResult
 {
   ScopesResponse(bool success, Scopes *cmd, std::array<Scope, 3> scopes) noexcept;
   ~ScopesResponse() noexcept override = default;
-  std::string serialize(int seq) const noexcept final;
+  std::string Serialize(int seq) const noexcept final;
   // For now, we only have 3 scopes, Args, Locals, Registers
   std::array<Scope, 3> scopes;
 };
@@ -668,7 +668,7 @@ struct Evaluate final : public UICommand
   Evaluate(u64 seq, std::string &&expression, std::optional<int> frameId,
            std::optional<EvaluationContext> context) noexcept;
   ~Evaluate() noexcept final = default;
-  UIResultPtr execute() noexcept final;
+  UIResultPtr Execute() noexcept final;
 
   Immutable<std::string> expr;
   Immutable<std::optional<int>> frameId;
@@ -687,7 +687,7 @@ struct EvaluateResponse final : public UIResult
   EvaluateResponse(bool success, Evaluate *cmd, std::optional<int> variablesReference, std::string &&result,
                    std::optional<std::string> &&type, std::optional<std::string> &&memoryReference) noexcept;
   ~EvaluateResponse() noexcept override = default;
-  std::string serialize(int seq) const noexcept final;
+  std::string Serialize(int seq) const noexcept final;
 
   std::string result;
   std::optional<std::string> type;
@@ -699,7 +699,7 @@ struct Variables final : public UICommand
 {
   Variables(u64 seq, int var_ref, std::optional<u32> start, std::optional<u32> count) noexcept;
   ~Variables() override = default;
-  UIResultPtr execute() noexcept final;
+  UIResultPtr Execute() noexcept final;
   ErrorResponse *error(std::string &&msg) noexcept;
   int var_ref;
   std::optional<u32> start;
@@ -713,7 +713,7 @@ struct VariablesResponse final : public UIResult
 {
   VariablesResponse(bool success, Variables *cmd, std::vector<Variable> &&vars) noexcept;
   ~VariablesResponse() noexcept override = default;
-  std::string serialize(int seq) const noexcept final;
+  std::string Serialize(int seq) const noexcept final;
   int requested_reference;
   std::vector<Variable> variables;
 };
@@ -722,7 +722,7 @@ struct DisassembleResponse final : public UIResult
 {
   CTOR(DisassembleResponse);
   ~DisassembleResponse() noexcept override = default;
-  std::string serialize(int seq) const noexcept final;
+  std::string Serialize(int seq) const noexcept final;
   std::vector<sym::Disassembly> instructions;
 };
 
@@ -731,7 +731,7 @@ struct Disassemble final : public UICommand
   Disassemble(u64 seq, std::optional<AddrPtr> address, int byte_offset, int ins_offset, int ins_count,
               bool resolve_symbols) noexcept;
   ~Disassemble() override = default;
-  UIResultPtr execute() noexcept final;
+  UIResultPtr Execute() noexcept final;
 
   std::optional<AddrPtr> address;
   int byte_offset;
@@ -748,7 +748,7 @@ struct InvalidArgsResponse final : public UIResult
 {
   InvalidArgsResponse(std::string_view command, MissingOrInvalidArgs &&missing_args) noexcept;
   ~InvalidArgsResponse() noexcept override = default;
-  std::string serialize(int seq) const noexcept final;
+  std::string Serialize(int seq) const noexcept final;
   std::string_view command;
   MissingOrInvalidArgs missing_or_invalid;
 };
@@ -763,7 +763,7 @@ struct InvalidArgs final : public UICommand
   InvalidArgs(u64 seq, std::string_view command, MissingOrInvalidArgs &&missing_args) noexcept;
   ~InvalidArgs() override = default;
 
-  UIResultPtr execute() noexcept final;
+  UIResultPtr Execute() noexcept final;
 
   ArgumentErrorKind kind;
   std::string_view command;

--- a/src/interface/dap/commands.h
+++ b/src/interface/dap/commands.h
@@ -1,12 +1,15 @@
 #pragma once
 #include <interface/ui_command.h>
 #include <interface/ui_result.h>
+#include <memory_resource>
 #include <span>
 // NOLINTNEXTLINE
 #include "bp.h"
 #include "fmt/ranges.h"
+#include "interface/dap/interface.h"
 #include "types.h"
 #include <interface/attach_args.h>
+#include <lib/arena_allocator.h>
 #include <nlohmann/json.hpp>
 #include <symbolication/disassemble.h>
 #include <typedefs.h>
@@ -205,7 +208,7 @@ struct ErrorResponse final : ui::UIResult
   ErrorResponse(std::string_view command, ui::UICommandPtr cmd, std::optional<std::string> &&short_message,
                 std::optional<Message> &&message) noexcept;
   ~ErrorResponse() noexcept override = default;
-  std::string Serialize(int seq) const noexcept final;
+  std::pmr::string Serialize(int seq, std::pmr::memory_resource* arenaAllocator) const noexcept final;
 
   std::string_view command;
   std::optional<std::string> short_message;
@@ -217,7 +220,7 @@ struct ReverseContinueResponse final : ui::UIResult
   CTOR(ReverseContinueResponse);
   ~ReverseContinueResponse() noexcept override = default;
   bool continue_all;
-  std::string Serialize(int seq) const noexcept final;
+  std::pmr::string Serialize(int seq, std::pmr::memory_resource* arenaAllocator) const noexcept final;
 };
 
 /** ReverseContinue under RR is *always* "continue all"*/
@@ -238,7 +241,7 @@ struct ContinueResponse final : ui::UIResult
   CTOR(ContinueResponse);
   ~ContinueResponse() noexcept override = default;
   bool continue_all;
-  std::string Serialize(int seq) const noexcept final;
+  std::pmr::string Serialize(int seq, std::pmr::memory_resource* arenaAllocator) const noexcept final;
 };
 
 struct Continue final : public ui::UICommand
@@ -259,7 +262,7 @@ struct PauseResponse final : ui::UIResult
 {
   CTOR(PauseResponse);
   ~PauseResponse() noexcept override = default;
-  std::string Serialize(int seq) const noexcept final;
+  std::pmr::string Serialize(int seq, std::pmr::memory_resource* arenaAllocator) const noexcept final;
 };
 
 struct Pause final : public ui::UICommand
@@ -290,7 +293,7 @@ struct NextResponse final : ui::UIResult
 {
   CTOR(NextResponse);
   ~NextResponse() noexcept override = default;
-  std::string Serialize(int seq) const noexcept final;
+  std::pmr::string Serialize(int seq, std::pmr::memory_resource* arenaAllocator) const noexcept final;
 };
 
 struct Next final : public ui::UICommand
@@ -314,7 +317,7 @@ struct StepInResponse final : ui::UIResult
 {
   CTOR(StepInResponse);
   ~StepInResponse() noexcept override = default;
-  std::string Serialize(int seq) const noexcept final;
+  std::pmr::string Serialize(int seq, std::pmr::memory_resource* arenaAllocator) const noexcept final;
 };
 
 struct StepIn final : public ui::UICommand
@@ -339,7 +342,7 @@ struct StepOutResponse final : ui::UIResult
 {
   CTOR(StepOutResponse);
   ~StepOutResponse() noexcept override = default;
-  std::string Serialize(int seq) const noexcept final;
+  std::pmr::string Serialize(int seq, std::pmr::memory_resource* arenaAllocator) const noexcept final;
 };
 
 struct StepOut final : public ui::UICommand
@@ -363,7 +366,7 @@ struct SetBreakpointsResponse final : ui::UIResult
   BreakpointRequestKind type;
   std::vector<ui::dap::Breakpoint> breakpoints;
   ~SetBreakpointsResponse() noexcept override = default;
-  std::string Serialize(int seq) const noexcept final;
+  std::pmr::string Serialize(int seq, std::pmr::memory_resource* arenaAllocator) const noexcept final;
 };
 
 struct SetBreakpoints final : public ui::UICommand
@@ -413,7 +416,7 @@ struct WriteMemoryResponse final : public ui::UIResult
 {
   CTOR(WriteMemoryResponse);
   ~WriteMemoryResponse() noexcept override = default;
-  std::string Serialize(int seq) const noexcept final;
+  std::pmr::string Serialize(int seq, std::pmr::memory_resource* arenaAllocator) const noexcept final;
   u64 bytes_written;
 };
 
@@ -436,7 +439,7 @@ struct ReadMemoryResponse final : public ui::UIResult
 {
   CTOR(ReadMemoryResponse);
   ~ReadMemoryResponse() noexcept override = default;
-  std::string Serialize(int seq) const noexcept final;
+  std::pmr::string Serialize(int seq, std::pmr::memory_resource* arenaAllocator) const noexcept final;
   AddrPtr first_readable_address;
   u64 unreadable_bytes;
   std::string data_base64;
@@ -461,7 +464,7 @@ struct ConfigurationDoneResponse final : public ui::UIResult
 {
   CTOR(ConfigurationDoneResponse);
   ~ConfigurationDoneResponse() noexcept override = default;
-  std::string Serialize(int seq) const noexcept final;
+  std::pmr::string Serialize(int seq, std::pmr::memory_resource* arenaAllocator) const noexcept final;
 };
 
 struct ConfigurationDone final : public ui::UICommand
@@ -479,7 +482,7 @@ struct InitializeResponse final : public ui::UIResult
   CTOR(InitializeResponse);
   InitializeResponse(bool rrsession, bool ok, UICommandPtr cmd) noexcept;
   ~InitializeResponse() noexcept override = default;
-  std::string Serialize(int seq) const noexcept final;
+  std::pmr::string Serialize(int seq, std::pmr::memory_resource* arenaAllocator) const noexcept final;
 
   bool RRSession;
 };
@@ -498,7 +501,7 @@ struct DisconnectResponse final : public UIResult
 {
   CTOR(DisconnectResponse);
   ~DisconnectResponse() noexcept override = default;
-  std::string Serialize(int seq) const noexcept final;
+  std::pmr::string Serialize(int seq, std::pmr::memory_resource* arenaAllocator) const noexcept final;
 };
 
 struct Disconnect final : public UICommand
@@ -515,7 +518,7 @@ struct LaunchResponse final : public UIResult
 {
   CTOR(LaunchResponse);
   ~LaunchResponse() noexcept override = default;
-  std::string Serialize(int seq) const noexcept final;
+  std::pmr::string Serialize(int seq, std::pmr::memory_resource* arenaAllocator) const noexcept final;
 };
 
 struct Launch final : public UICommand
@@ -535,7 +538,7 @@ struct AttachResponse final : public UIResult
 {
   CTOR(AttachResponse);
   ~AttachResponse() noexcept override = default;
-  std::string Serialize(int seq) const noexcept final;
+  std::pmr::string Serialize(int seq, std::pmr::memory_resource* arenaAllocator) const noexcept final;
 };
 
 struct Attach final : public UICommand
@@ -581,7 +584,7 @@ struct TerminateResponse final : public UIResult
 {
   CTOR(TerminateResponse);
   ~TerminateResponse() noexcept override = default;
-  std::string Serialize(int seq) const noexcept final;
+  std::pmr::string Serialize(int seq, std::pmr::memory_resource* arenaAllocator) const noexcept final;
 };
 
 struct Terminate final : public UICommand
@@ -597,7 +600,7 @@ struct ThreadsResponse final : public UIResult
 {
   CTOR(ThreadsResponse);
   ~ThreadsResponse() noexcept override = default;
-  std::string Serialize(int seq) const noexcept final;
+  std::pmr::string Serialize(int seq, std::pmr::memory_resource* arenaAllocator) const noexcept final;
   std::vector<Thread> threads;
 };
 
@@ -630,7 +633,7 @@ struct StackTraceResponse final : public UIResult
   CTOR(StackTraceResponse);
   StackTraceResponse(bool success, StackTrace *cmd, std::vector<StackFrame> &&stack_frames) noexcept;
   ~StackTraceResponse() noexcept override = default;
-  std::string Serialize(int seq) const noexcept final;
+  std::pmr::string Serialize(int seq, std::pmr::memory_resource* arenaAllocator) const noexcept final;
   std::vector<StackFrame> stack_frames;
 };
 
@@ -649,7 +652,7 @@ struct ScopesResponse final : public UIResult
 {
   ScopesResponse(bool success, Scopes *cmd, std::array<Scope, 3> scopes) noexcept;
   ~ScopesResponse() noexcept override = default;
-  std::string Serialize(int seq) const noexcept final;
+  std::pmr::string Serialize(int seq, std::pmr::memory_resource* arenaAllocator) const noexcept final;
   // For now, we only have 3 scopes, Args, Locals, Registers
   std::array<Scope, 3> scopes;
 };
@@ -687,7 +690,7 @@ struct EvaluateResponse final : public UIResult
   EvaluateResponse(bool success, Evaluate *cmd, std::optional<int> variablesReference, std::string &&result,
                    std::optional<std::string> &&type, std::optional<std::string> &&memoryReference) noexcept;
   ~EvaluateResponse() noexcept override = default;
-  std::string Serialize(int seq) const noexcept final;
+  std::pmr::string Serialize(int seq, std::pmr::memory_resource* arenaAllocator) const noexcept final;
 
   std::string result;
   std::optional<std::string> type;
@@ -713,7 +716,7 @@ struct VariablesResponse final : public UIResult
 {
   VariablesResponse(bool success, Variables *cmd, std::vector<Variable> &&vars) noexcept;
   ~VariablesResponse() noexcept override = default;
-  std::string Serialize(int seq) const noexcept final;
+  std::pmr::string Serialize(int seq, std::pmr::memory_resource* arenaAllocator) const noexcept final;
   int requested_reference;
   std::vector<Variable> variables;
 };
@@ -722,7 +725,7 @@ struct DisassembleResponse final : public UIResult
 {
   CTOR(DisassembleResponse);
   ~DisassembleResponse() noexcept override = default;
-  std::string Serialize(int seq) const noexcept final;
+  std::pmr::string Serialize(int seq, std::pmr::memory_resource* arenaAllocator) const noexcept final;
   std::vector<sym::Disassembly> instructions;
 };
 
@@ -748,7 +751,7 @@ struct InvalidArgsResponse final : public UIResult
 {
   InvalidArgsResponse(std::string_view command, MissingOrInvalidArgs &&missing_args) noexcept;
   ~InvalidArgsResponse() noexcept override = default;
-  std::string Serialize(int seq) const noexcept final;
+  std::pmr::string Serialize(int seq, std::pmr::memory_resource* arenaAllocator) const noexcept final;
   std::string_view command;
   MissingOrInvalidArgs missing_or_invalid;
 };
@@ -785,44 +788,3 @@ Validate(uint64_t seq, const JsonArgs &args) -> InvalidArgs *
   }
 }
 }; // namespace ui::dap
-
-namespace fmt {
-
-template <> struct formatter<ui::dap::Message>
-{
-  template <typename ParseContext>
-  constexpr auto
-  parse(ParseContext &ctx)
-  {
-    return ctx.begin();
-  }
-
-  template <typename FormatContext>
-  auto
-  format(const ui::dap::Message &msg, FormatContext &ctx) const
-  {
-
-    if (msg.variables.empty()) {
-      return fmt::format_to(ctx.out(), R"({{"id":{},"format":"{}","showUser":{}}})", msg.id.value_or(-1),
-                            msg.format, msg.show_user);
-    } else {
-      std::vector<char> buf{0};
-      buf.reserve(256);
-      auto sz = 1u;
-      auto max = msg.variables.size();
-      for (const auto &[k, v] : msg.variables) {
-        if (sz < max) {
-          fmt::format_to(std::back_inserter(buf), R"("{}":"{}", )", k, v);
-        } else {
-          fmt::format_to(std::back_inserter(buf), R"("{}":"{}")", k, v);
-        }
-        ++sz;
-      }
-      buf.push_back(0);
-      return fmt::format_to(ctx.out(), R"({{ "id": {}, "format": "{}", "variables":{{ {} }}, "showUser":{}}})",
-                            msg.id.value_or(-1), msg.format, fmt::join(buf, ""), msg.show_user);
-    }
-  }
-};
-
-} // namespace fmt

--- a/src/interface/dap/events.cpp
+++ b/src/interface/dap/events.cpp
@@ -10,13 +10,13 @@
 namespace ui::dap {
 
 std::string
-InitializedEvent::serialize(int) const noexcept
+InitializedEvent::Serialize(int) const noexcept
 {
   return fmt::format(R"({{"seq":{}, "type":"event", "event":"initialized" }})", 1);
 }
 
 std::string
-TerminatedEvent::serialize(int seq) const noexcept
+TerminatedEvent::Serialize(int seq) const noexcept
 {
   return fmt::format(R"({{"seq":{}, "type":"event", "event":"terminated" }})", seq);
 }
@@ -62,7 +62,7 @@ format_optional(const std::optional<T> &opt, bool with_quotes) noexcept -> std::
 }
 
 std::string
-ModuleEvent::serialize(int seq) const noexcept
+ModuleEvent::Serialize(int seq) const noexcept
 {
   auto out = fmt::memory_buffer();
   constexpr auto bi = [](auto &out) { return std::back_inserter(out); };
@@ -91,7 +91,7 @@ ContinuedEvent::ContinuedEvent(Tid tid, bool all_threads) noexcept
 }
 
 std::string
-ContinuedEvent::serialize(int seq) const noexcept
+ContinuedEvent::Serialize(int seq) const noexcept
 {
   return fmt::format(
     R"({{"seq":{}, "type":"event", "event":"continued", "body":{{"threadId":{}, "allThreadsContinued":{}}}}})",
@@ -101,7 +101,7 @@ ContinuedEvent::serialize(int seq) const noexcept
 Process::Process(std::string name, bool is_local) noexcept : name(std::move(name)), is_local(is_local) {}
 
 std::string
-Process::serialize(int seq) const noexcept
+Process::Serialize(int seq) const noexcept
 {
   return fmt::format(
     R"({{"seq":{}, "type":"event", "event":"process", "body":{{"name":"{}", "isLocalProcess": true, "startMethod": "attach" }}}})",
@@ -110,7 +110,7 @@ Process::serialize(int seq) const noexcept
 
 ExitedEvent::ExitedEvent(int exit_code) noexcept : exit_code(exit_code) {}
 std::string
-ExitedEvent::serialize(int seq) const noexcept
+ExitedEvent::Serialize(int seq) const noexcept
 {
   return fmt::format(R"({{"seq":{}, "type":"event", "event":"exited", "body":{{"exitCode":{}}}}})", seq,
                      exit_code);
@@ -119,7 +119,7 @@ ExitedEvent::serialize(int seq) const noexcept
 ThreadEvent::ThreadEvent(ThreadReason reason, Tid tid) noexcept : reason(reason), tid(tid) {}
 
 std::string
-ThreadEvent::serialize(int seq) const noexcept
+ThreadEvent::Serialize(int seq) const noexcept
 {
   return fmt::format(R"({{"seq":{}, "type":"event", "event":"thread", "body":{{"reason":"{}", "threadId":{}}}}})",
                      seq, to_str(reason), tid);
@@ -132,7 +132,7 @@ StoppedEvent::StoppedEvent(StoppedReason reason, std::string_view description, T
 }
 
 std::string
-StoppedEvent::serialize(int seq) const noexcept
+StoppedEvent::Serialize(int seq) const noexcept
 {
   nlohmann::json ensure_desc_utf8 = description;
   const auto description_utf8 = ensure_desc_utf8.dump();
@@ -167,7 +167,7 @@ zip(Fn &&fn, Optionals... opts) noexcept
 }
 
 std::string
-BreakpointEvent::serialize(int seq) const noexcept
+BreakpointEvent::Serialize(int seq) const noexcept
 {
 
   std::string result{};
@@ -204,7 +204,7 @@ OutputEvent::OutputEvent(std::string_view category, std::string &&output) noexce
 }
 
 std::string
-OutputEvent::serialize(int seq) const noexcept
+OutputEvent::Serialize(int seq) const noexcept
 {
   nlohmann::json escape_hack;
   escape_hack = output;

--- a/src/interface/dap/events.h
+++ b/src/interface/dap/events.h
@@ -24,14 +24,14 @@ struct InitializedEvent final : public ui::UIResult
 {
   InitializedEvent() noexcept = default;
   ~InitializedEvent() noexcept final = default;
-  std::string serialize(int seq) const noexcept final;
+  std::string Serialize(int seq) const noexcept final;
 };
 
 struct TerminatedEvent final : public ui::UIResult
 {
   TerminatedEvent() noexcept = default;
   ~TerminatedEvent() noexcept final = default;
-  std::string serialize(int seq) const noexcept final;
+  std::string Serialize(int seq) const noexcept final;
 };
 
 static constexpr std::string_view reasons[3]{"new", "changed", "removed"};
@@ -54,7 +54,7 @@ struct ModuleEvent final : public ui::UIResult
   std::optional<std::string> symbol_file_path;
   std::optional<std::string> version;
 
-  std::string serialize(int seq) const noexcept final;
+  std::string Serialize(int seq) const noexcept final;
 };
 
 struct ContinuedEvent final : public ui::UIResult
@@ -64,7 +64,7 @@ struct ContinuedEvent final : public ui::UIResult
   // allThreadsContinued
   bool all_threads_continued;
   ContinuedEvent(Tid tid, bool all_threads) noexcept;
-  std::string serialize(int seq) const noexcept final;
+  std::string Serialize(int seq) const noexcept final;
 };
 
 struct Process final : public ui::UIResult
@@ -72,7 +72,7 @@ struct Process final : public ui::UIResult
   std::string name;
   bool is_local;
   Process(std::string name, bool is_local) noexcept;
-  std::string serialize(int seq) const noexcept final;
+  std::string Serialize(int seq) const noexcept final;
 };
 
 struct ExitedEvent final : public ui::UIResult
@@ -80,14 +80,14 @@ struct ExitedEvent final : public ui::UIResult
   // exitCode
   int exit_code;
   ExitedEvent(int exit_code) noexcept;
-  std::string serialize(int seq) const noexcept final;
+  std::string Serialize(int seq) const noexcept final;
 };
 
 struct ThreadEvent final : public ui::UIResult
 {
   ThreadEvent(ThreadReason reason, Tid tid) noexcept;
   ~ThreadEvent() noexcept override = default;
-  std::string serialize(int seq) const noexcept final;
+  std::string Serialize(int seq) const noexcept final;
   ThreadReason reason;
   Tid tid;
 };
@@ -105,7 +105,7 @@ struct StoppedEvent final : public ui::UIResult
   // static additional information, name of exception for instance
   std::string_view text;
   bool all_threads_stopped;
-  std::string serialize(int seq) const noexcept final;
+  std::string Serialize(int seq) const noexcept final;
 };
 
 struct BreakpointEvent final : public ui::UIResult
@@ -116,7 +116,7 @@ struct BreakpointEvent final : public ui::UIResult
   BreakpointEvent(std::string_view reason, std::optional<std::string> message,
                   const UserBreakpoint *breakpoint) noexcept;
   ~BreakpointEvent() override = default;
-  std::string serialize(int seq) const noexcept final;
+  std::string Serialize(int seq) const noexcept final;
 };
 
 struct OutputEvent final : public ui::UIResult
@@ -126,7 +126,7 @@ struct OutputEvent final : public ui::UIResult
 
   std::string_view category; // static category strings exist, we always pass literals to this
   std::string output;
-  std::string serialize(int seq) const noexcept final;
+  std::string Serialize(int seq) const noexcept final;
 };
 
 }; // namespace ui::dap

--- a/src/interface/dap/events.h
+++ b/src/interface/dap/events.h
@@ -24,14 +24,14 @@ struct InitializedEvent final : public ui::UIResult
 {
   InitializedEvent() noexcept = default;
   ~InitializedEvent() noexcept final = default;
-  std::string Serialize(int seq) const noexcept final;
+  std::pmr::string Serialize(int monotonic_id, std::pmr::memory_resource* allocator=nullptr) const noexcept final;
 };
 
 struct TerminatedEvent final : public ui::UIResult
 {
   TerminatedEvent() noexcept = default;
   ~TerminatedEvent() noexcept final = default;
-  std::string Serialize(int seq) const noexcept final;
+  std::pmr::string Serialize(int monotonic_id, std::pmr::memory_resource* allocator=nullptr) const noexcept final;
 };
 
 static constexpr std::string_view reasons[3]{"new", "changed", "removed"};
@@ -54,7 +54,7 @@ struct ModuleEvent final : public ui::UIResult
   std::optional<std::string> symbol_file_path;
   std::optional<std::string> version;
 
-  std::string Serialize(int seq) const noexcept final;
+  std::pmr::string Serialize(int monotonic_id, std::pmr::memory_resource* allocator=nullptr) const noexcept final;
 };
 
 struct ContinuedEvent final : public ui::UIResult
@@ -64,7 +64,7 @@ struct ContinuedEvent final : public ui::UIResult
   // allThreadsContinued
   bool all_threads_continued;
   ContinuedEvent(Tid tid, bool all_threads) noexcept;
-  std::string Serialize(int seq) const noexcept final;
+  std::pmr::string Serialize(int monotonic_id, std::pmr::memory_resource* allocator=nullptr) const noexcept final;
 };
 
 struct Process final : public ui::UIResult
@@ -72,7 +72,7 @@ struct Process final : public ui::UIResult
   std::string name;
   bool is_local;
   Process(std::string name, bool is_local) noexcept;
-  std::string Serialize(int seq) const noexcept final;
+  std::pmr::string Serialize(int monotonic_id, std::pmr::memory_resource* allocator=nullptr) const noexcept final;
 };
 
 struct ExitedEvent final : public ui::UIResult
@@ -80,14 +80,14 @@ struct ExitedEvent final : public ui::UIResult
   // exitCode
   int exit_code;
   ExitedEvent(int exit_code) noexcept;
-  std::string Serialize(int seq) const noexcept final;
+  std::pmr::string Serialize(int monotonic_id, std::pmr::memory_resource* allocator=nullptr) const noexcept final;
 };
 
 struct ThreadEvent final : public ui::UIResult
 {
   ThreadEvent(ThreadReason reason, Tid tid) noexcept;
   ~ThreadEvent() noexcept override = default;
-  std::string Serialize(int seq) const noexcept final;
+  std::pmr::string Serialize(int monotonic_id, std::pmr::memory_resource* allocator=nullptr) const noexcept final;
   ThreadReason reason;
   Tid tid;
 };
@@ -105,7 +105,7 @@ struct StoppedEvent final : public ui::UIResult
   // static additional information, name of exception for instance
   std::string_view text;
   bool all_threads_stopped;
-  std::string Serialize(int seq) const noexcept final;
+  std::pmr::string Serialize(int monotonic_id, std::pmr::memory_resource* allocator=nullptr) const noexcept final;
 };
 
 struct BreakpointEvent final : public ui::UIResult
@@ -116,7 +116,7 @@ struct BreakpointEvent final : public ui::UIResult
   BreakpointEvent(std::string_view reason, std::optional<std::string> message,
                   const UserBreakpoint *breakpoint) noexcept;
   ~BreakpointEvent() override = default;
-  std::string Serialize(int seq) const noexcept final;
+  std::pmr::string Serialize(int monotonic_id, std::pmr::memory_resource* allocator=nullptr) const noexcept final;
 };
 
 struct OutputEvent final : public ui::UIResult
@@ -126,7 +126,7 @@ struct OutputEvent final : public ui::UIResult
 
   std::string_view category; // static category strings exist, we always pass literals to this
   std::string output;
-  std::string Serialize(int seq) const noexcept final;
+  std::pmr::string Serialize(int monotonic_id, std::pmr::memory_resource* allocator) const noexcept final;
 };
 
 }; // namespace ui::dap

--- a/src/interface/dap/interface.cpp
+++ b/src/interface/dap/interface.cpp
@@ -194,7 +194,7 @@ DAP::one_poll(u32 notifier_queue_size) noexcept
           continue;
         }
         std::string_view data{tracee_stdout_buffer, static_cast<u64>(bytes_read)};
-        client->write(ui::dap::OutputEvent{"stdout", std::string{data}}.serialize(0));
+        client->write(ui::dap::OutputEvent{"stdout", std::string{data}}.Serialize(0));
       } break;
       }
     }
@@ -288,7 +288,7 @@ DAP::flush_events() noexcept
 {
   while (!events_queue.empty()) {
     auto evt = pop_event();
-    const auto protocol_msg = evt->serialize(0);
+    const auto protocol_msg = evt->Serialize(0);
     write_protocol_message(protocol_msg);
     delete evt;
   }
@@ -425,7 +425,7 @@ DebugAdapterClient::post_event(ui::UIResultPtr event)
   // now, 1 thread for all debug adapter client, that does it's dispatching vie the poll system calls. If we land,
   // 100% in the idea to keep it this way, we shouldn't really have to `new` and `delete` UIResultPtr's, that
   // should just be on the stack; but I'm keeping it here for now, in case I want to try out the other way.
-  auto result = event->serialize(0);
+  auto result = event->Serialize(0);
   write(result);
   delete event;
 }

--- a/src/interface/dap/interface.h
+++ b/src/interface/dap/interface.h
@@ -144,6 +144,8 @@ class DebugAdapterClient
   // UICommand upon destruction, calls mCommandsAllocator.Reset(), at which point all allocations beautifully melt
   // away.
   std::unique_ptr<ArenaAllocator> mCommandsAllocator;
+  std::unique_ptr<ArenaAllocator> mCommandResponseAllocator;
+  std::unique_ptr<ArenaAllocator> mEventsAllocator;
 
   DebugAdapterClient(DapClientSession session, std::filesystem::path &&path, int socket_fd) noexcept;
   // Most likely used as the initial DA Client Connection (which tends to be via standard in/out, but don't have to
@@ -153,11 +155,14 @@ class DebugAdapterClient
   std::mutex m{};
   std::queue<UIResultPtr> ui_output_queue{};
 
+  void InitAllocators() noexcept;
+
 public:
   DapClientSession session_type;
   ~DebugAdapterClient() noexcept;
 
-  ArenaAllocator& GetCommandArenaAllocator() noexcept;
+  ArenaAllocator* GetCommandArenaAllocator() noexcept;
+  ArenaAllocator* GetResponseArenaAllocator() noexcept;
   static DebugAdapterClient *createStandardIOConnection() noexcept;
   static DebugAdapterClient *createSocketConnection(DebugAdapterClient *client) noexcept;
   void client_configured(TraceeController *tc) noexcept;
@@ -188,10 +193,11 @@ class DAP
 private:
   std::vector<utils::OwningPointer<DebugAdapterClient>> clients{};
   std::vector<NotifSource> sources{};
+  std::unique_ptr<ArenaAllocator> mTemporaryArena;
 
 public:
   explicit DAP(Tracer *tracer, int tracer_input_fd, int tracer_output_fd) noexcept;
-  ~DAP() = default;
+  ~DAP() noexcept;
 
   // After setup we call `infinite_poll` that does what the name suggests, polls for messages. We could say that
   // this function never returns, but that might not necessarily be the case. In a normal execution it will,

--- a/src/interface/dap/interface.h
+++ b/src/interface/dap/interface.h
@@ -15,6 +15,8 @@ class Tracer;
 class TraceeController;
 /* The different DAP commands/requests */
 
+class ArenaAllocator;
+
 namespace ui {
 struct UIResult;
 using UIResultPtr = const UIResult *;
@@ -138,6 +140,10 @@ class DebugAdapterClient
   ParseBuffer parse_swapbuffer{MDB_PAGE_SIZE * 16};
   int tty_fd{-1};
   TraceeController *tc{nullptr};
+  // The allocator that can be used by commands during execution of them, for temporary objects etc
+  // UICommand upon destruction, calls mCommandsAllocator.Reset(), at which point all allocations beautifully melt
+  // away.
+  std::unique_ptr<ArenaAllocator> mCommandsAllocator;
 
   DebugAdapterClient(DapClientSession session, std::filesystem::path &&path, int socket_fd) noexcept;
   // Most likely used as the initial DA Client Connection (which tends to be via standard in/out, but don't have to
@@ -151,6 +157,7 @@ public:
   DapClientSession session_type;
   ~DebugAdapterClient() noexcept;
 
+  ArenaAllocator& GetCommandArenaAllocator() noexcept;
   static DebugAdapterClient *createStandardIOConnection() noexcept;
   static DebugAdapterClient *createSocketConnection(DebugAdapterClient *client) noexcept;
   void client_configured(TraceeController *tc) noexcept;

--- a/src/interface/dap/types.cpp
+++ b/src/interface/dap/types.cpp
@@ -1,14 +1,14 @@
 #include "types.h"
-#include "common.h"
 #include <iterator>
+#include <memory_resource>
 #include <supervisor.h>
 
 namespace ui::dap {
 
-std::string
-Breakpoint::serialize() const noexcept
+std::pmr::string
+Breakpoint::serialize(std::pmr::memory_resource* memoryResource) const noexcept
 {
-  std::string buf{};
+  std::pmr::string buf{memoryResource};
   // TODO(simon): Here we really should be using some form of arena allocation for the DAP interpreter
   // communication
   //  so that all these allocations can be "blinked" out of existence, i.e. all serialized command results, will be

--- a/src/interface/dap/types.h
+++ b/src/interface/dap/types.h
@@ -3,6 +3,7 @@
 #include "utils/immutable.h"
 #include "utils/macros.h"
 #include <fmt/format.h>
+#include <memory_resource>
 #include <string_view>
 #include <typedefs.h>
 
@@ -36,7 +37,7 @@ struct Breakpoint
   std::optional<std::string_view> source_path;
   std::optional<std::string> error_message;
 
-  std::string serialize() const noexcept;
+  std::pmr::string serialize(std::pmr::memory_resource* memoryResource) const noexcept;
   static Breakpoint non_verified(u32 id, std::string_view msg) noexcept;
   static Breakpoint from_user_bp(const UserBreakpoint& user_bp) noexcept;
 };

--- a/src/interface/ui_command.h
+++ b/src/interface/ui_command.h
@@ -99,7 +99,7 @@ public:
 
   /* Executes the command. This is always performed in the Tracer thread (where all tracee controller actions are
    * performed. )*/
-  virtual UIResultPtr execute() noexcept = 0;
+  virtual UIResultPtr Execute() noexcept = 0;
 
   template <typename Derived, typename JsonArgs>
   static constexpr MissingOrInvalidResult

--- a/src/interface/ui_result.h
+++ b/src/interface/ui_result.h
@@ -12,7 +12,7 @@ struct UIResult
   {
   }
   virtual ~UIResult() = default;
-  virtual std::string serialize(int monotonic_id) const noexcept = 0;
+  virtual std::string Serialize(int monotonic_id) const noexcept = 0;
 
   bool success;
   std::uint64_t request_seq;

--- a/src/interface/ui_result.h
+++ b/src/interface/ui_result.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "ui_command.h"
+#include <memory_resource>
 #include <string>
 
 namespace ui {
@@ -12,7 +13,7 @@ struct UIResult
   {
   }
   virtual ~UIResult() = default;
-  virtual std::string Serialize(int monotonic_id) const noexcept = 0;
+  virtual std::pmr::string Serialize(int monotonic_id, std::pmr::memory_resource* allocator) const noexcept = 0;
 
   bool success;
   std::uint64_t request_seq;

--- a/src/lib/arena_allocator.cpp
+++ b/src/lib/arena_allocator.cpp
@@ -1,0 +1,68 @@
+#include "arena_allocator.h"
+#include "common.h"
+#include "tracee/util.h"
+#include <cstdlib>
+#include <memory_resource>
+
+ArenaAllocator::ArenaAllocator(std::size_t allocBlockSize, std::pmr::memory_resource *upstreamResource) noexcept
+    : mResource(upstreamResource), mAllocated(0), mArenaCapacity(allocBlockSize)
+{
+  int allocResult = posix_memalign((void **)&mAllocatedBuffer, SystemVectorExtensionSize(), allocBlockSize);
+  MUST_HOLD(allocResult == 0, "posix_memalign failed");
+}
+
+ArenaAllocator::~ArenaAllocator() noexcept { free(mAllocatedBuffer); }
+
+/*static*/
+ArenaAllocator::UniquePtr
+ArenaAllocator::Create(size_t allocSize, std::pmr::memory_resource *upstreamResource) noexcept
+{
+  return std::unique_ptr<ArenaAllocator>(new ArenaAllocator{allocSize, upstreamResource});
+}
+
+/*static*/
+ArenaAllocator::SharedPtr
+ArenaAllocator::CreateShared(size_t allocSize, std::pmr::memory_resource *upstreamResource) noexcept
+{
+  return std::shared_ptr<ArenaAllocator>(new ArenaAllocator{allocSize, upstreamResource});
+}
+
+void *
+ArenaAllocator::do_allocate(std::size_t bytes, std::size_t alignment)
+{
+  // (0b101 + 0b100 - 0b1) & ~(0b100 - 0b1 => 0b11)
+  //
+  const std::size_t possiblyAdjustedOffset = (mAllocated + alignment - 1) & ~(alignment - 1);
+  MUST_HOLD((possiblyAdjustedOffset + bytes) < mArenaCapacity,
+            "Dynamic arena allocator not yet implemented. For now we crash.");
+  void *p = mAllocatedBuffer + possiblyAdjustedOffset;
+  mAllocated = possiblyAdjustedOffset + bytes;
+  return p;
+}
+
+void
+ArenaAllocator::do_deallocate(void *p, std::size_t bytes, std::size_t alignment)
+{
+  MUST_HOLD(p < (mAllocatedBuffer + mArenaCapacity),
+            "The arena allocator doesn't support dynamic allocations when memory runs out, yet");
+}
+
+bool
+ArenaAllocator::do_is_equal(const std::pmr::memory_resource &other) const noexcept
+{
+  return this == &other;
+}
+
+template <size_t N>
+std::pmr::monotonic_buffer_resource &
+StackAllocator<N>::Resource() noexcept
+{
+  return mMemoryResource;
+}
+
+template <size_t N>
+std::pmr::polymorphic_allocator<> &
+StackAllocator<N>::Allocator() noexcept
+{
+  return mUsingStackAllocator;
+}

--- a/src/lib/arena_allocator.cpp
+++ b/src/lib/arena_allocator.cpp
@@ -30,8 +30,6 @@ ArenaAllocator::CreateShared(size_t allocSize, std::pmr::memory_resource *upstre
 void *
 ArenaAllocator::do_allocate(std::size_t bytes, std::size_t alignment)
 {
-  // (0b101 + 0b100 - 0b1) & ~(0b100 - 0b1 => 0b11)
-  //
   const std::size_t possiblyAdjustedOffset = (mAllocated + alignment - 1) & ~(alignment - 1);
   MUST_HOLD((possiblyAdjustedOffset + bytes) < mArenaCapacity,
             "Dynamic arena allocator not yet implemented. For now we crash.");

--- a/src/lib/arena_allocator.h
+++ b/src/lib/arena_allocator.h
@@ -1,18 +1,42 @@
 #pragma once
 #include "typedefs.h"
+#include "utils/macros.h"
+#include "utils/scope_defer.h"
 #include <memory>
 #include <memory_resource>
 #include <sys/user.h>
+
+class ArenaAllocator;
+
+// Class that takes a reference to a `ArenaAllocator` and upon exit of scope (destructor gets run) it resets the
+// arena.
+class ScopedArenaAllocator
+{
+  ArenaAllocator *mAllocator;
+
+public:
+  MOVE_ONLY(ScopedArenaAllocator);
+  explicit ScopedArenaAllocator(ArenaAllocator *allocator) noexcept;
+  ~ScopedArenaAllocator() noexcept;
+  ScopedArenaAllocator(ScopedArenaAllocator&& move) noexcept;
+
+  // I'm not sure a = std::move(b) makes sense for this type.
+  ScopedArenaAllocator& operator=(ScopedArenaAllocator&& move) noexcept = delete;
+
+  ArenaAllocator *GetAllocator() const noexcept;
+  operator ArenaAllocator *() const noexcept { return GetAllocator(); }
+};
 
 class ArenaAllocator : public std::pmr::memory_resource
 {
   std::pmr::memory_resource *mResource;
 
-  u8* mAllocatedBuffer;
+  u8 *mAllocatedBuffer;
   std::size_t mAllocated;
   std::size_t mArenaCapacity;
 
   ArenaAllocator(std::size_t allocBlockSize, std::pmr::memory_resource *upstreamResource) noexcept;
+
 public:
   using UniquePtr = std::unique_ptr<ArenaAllocator>;
   using SharedPtr = std::shared_ptr<ArenaAllocator>;
@@ -20,23 +44,25 @@ public:
 
   // Creates an arena allocator. `upstreamResource` can be null, if you don't want the arena allocator
   // to be able to allocate more memory than it's pre-allocated block.
-  static UniquePtr Create(size_t allocSize, std::pmr::memory_resource* upstreamResource) noexcept;
-  static SharedPtr CreateShared(size_t allocSize, std::pmr::memory_resource* upstreamResource) noexcept;
+  static UniquePtr Create(size_t allocSize, std::pmr::memory_resource *upstreamResource) noexcept;
+  static SharedPtr CreateShared(size_t allocSize, std::pmr::memory_resource *upstreamResource) noexcept;
+  void Reset() noexcept;
+  // Using RAII we can get the arena allocator to reset upon function exit
+  ScopedArenaAllocator ScopeAllocation() noexcept;
 
+  // Interface Implementation.
   void *do_allocate(std::size_t bytes, std::size_t alignment) override;
   void do_deallocate(void *p, std::size_t bytes, std::size_t alignment) override;
   bool do_is_equal(const std::pmr::memory_resource &other) const noexcept override;
-
-  void reset() noexcept;
 };
 
-template <size_t StackSize>
-class StackAllocator {
+template <size_t StackSize> class StackAllocator
+{
   std::array<u8, StackSize> mMemory;
   std::pmr::monotonic_buffer_resource mMemoryResource{mMemory.data(), mMemory.size() * sizeof(unsigned)};
   std::pmr::polymorphic_allocator<> mUsingStackAllocator{&mMemoryResource};
 
 public:
-  std::pmr::monotonic_buffer_resource& Resource() noexcept;
-  std::pmr::polymorphic_allocator<>& Allocator() noexcept;
+  std::pmr::monotonic_buffer_resource &Resource() noexcept;
+  std::pmr::polymorphic_allocator<> &Allocator() noexcept;
 };

--- a/src/lib/arena_allocator.h
+++ b/src/lib/arena_allocator.h
@@ -1,0 +1,42 @@
+#pragma once
+#include "typedefs.h"
+#include <memory>
+#include <memory_resource>
+#include <sys/user.h>
+
+class ArenaAllocator : public std::pmr::memory_resource
+{
+  std::pmr::memory_resource *mResource;
+
+  u8* mAllocatedBuffer;
+  std::size_t mAllocated;
+  std::size_t mArenaCapacity;
+
+  ArenaAllocator(std::size_t allocBlockSize, std::pmr::memory_resource *upstreamResource) noexcept;
+public:
+  using UniquePtr = std::unique_ptr<ArenaAllocator>;
+  using SharedPtr = std::shared_ptr<ArenaAllocator>;
+  ~ArenaAllocator() noexcept override;
+
+  // Creates an arena allocator. `upstreamResource` can be null, if you don't want the arena allocator
+  // to be able to allocate more memory than it's pre-allocated block.
+  static UniquePtr Create(size_t allocSize, std::pmr::memory_resource* upstreamResource) noexcept;
+  static SharedPtr CreateShared(size_t allocSize, std::pmr::memory_resource* upstreamResource) noexcept;
+
+  void *do_allocate(std::size_t bytes, std::size_t alignment) override;
+  void do_deallocate(void *p, std::size_t bytes, std::size_t alignment) override;
+  bool do_is_equal(const std::pmr::memory_resource &other) const noexcept override;
+
+  void reset() noexcept;
+};
+
+template <size_t StackSize>
+class StackAllocator {
+  std::array<u8, StackSize> mMemory;
+  std::pmr::monotonic_buffer_resource mMemoryResource{mMemory.data(), mMemory.size() * sizeof(unsigned)};
+  std::pmr::polymorphic_allocator<> mUsingStackAllocator{&mMemoryResource};
+
+public:
+  std::pmr::monotonic_buffer_resource& Resource() noexcept;
+  std::pmr::polymorphic_allocator<>& Allocator() noexcept;
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,6 +47,9 @@ utils::ThreadPool *utils::ThreadPool::global_thread_pool = new utils::ThreadPool
 int
 main(int argc, const char **argv)
 {
+  // Sets main thread id. It's static so subsequent calls from other threads should be fine.
+  GetMainThreadId();
+
   auto res = sys::parse_cli(argc, argv);
   if (!res.is_expected()) {
     auto &&err = res.error();

--- a/src/supervisor.h
+++ b/src/supervisor.h
@@ -218,7 +218,8 @@ public:
   GetOrCreateBreakpointLocation(AddrPtr addr, AddrPtr base, sym::dw::SourceCodeFile &src_code_file) noexcept;
 
   utils::Expected<std::shared_ptr<BreakpointLocation>, BpErr>
-  GetOrCreateBreakpointLocationWithSourceLoc(AddrPtr addr, std::optional<LocationSourceInfo> &&sourceLocInfo) noexcept;
+  GetOrCreateBreakpointLocationWithSourceLoc(AddrPtr addr,
+                                             std::optional<LocationSourceInfo> &&sourceLocInfo) noexcept;
   void SetSourceBreakpoints(const std::filesystem::path &source_filepath,
                             const Set<SourceBreakpointSpec> &bps) noexcept;
   void UpdateSourceBreakpoints(const std::filesystem::path &source_filepath,
@@ -264,6 +265,8 @@ public:
   TargetSession GetSessionType() const noexcept;
 
   utils::Expected<std::unique_ptr<utils::ByteBuffer>, NonFullRead> SafeRead(AddrPtr addr, u64 bytes) noexcept;
+  utils::Expected<std::unique_ptr<utils::ByteBuffer>, NonFullRead> SafeRead(std::pmr::memory_resource *allocator,
+                                                                            AddrPtr addr, u64 bytes) noexcept;
   utils::StaticVector<u8>::OwnPtr ReadToVector(AddrPtr addr, u64 bytes) noexcept;
 
   template <typename T>

--- a/src/symbolication/callstack.cpp
+++ b/src/symbolication/callstack.cpp
@@ -134,8 +134,10 @@ Frame::Scopes() noexcept
 sym::FunctionSymbol *
 Frame::MaybeGetFullSymbolInfo() const noexcept
 {
-  ASSERT(mFrameType == FrameType::Full, "Frame has no full symbol info");
-  return mSymbolUnion.uFullSymbol;
+  if(mFrameType == FrameType::Full) {
+    return mSymbolUnion.uFullSymbol;
+  }
+  return nullptr;
 }
 
 const MinSymbol *

--- a/src/symbolication/dwarf.h
+++ b/src/symbolication/dwarf.h
@@ -82,6 +82,13 @@ struct AttributeValue
   {
     return value.u;
   }
+
+  static inline u64
+  as_unsigned(const AttributeValue &v)
+  {
+    return v.unsigned_value();
+  }
+
   i64
   signed_value() const noexcept
   {

--- a/src/symbolication/dwarf/typeread.cpp
+++ b/src/symbolication/dwarf/typeread.cpp
@@ -15,6 +15,7 @@ FunctionSymbolicationContext::FunctionSymbolicationContext(ObjectFile &obj, sym:
       lexicalBlockStack({params})
 {
   ASSERT(lexicalBlockStack.size() == 1, "Expected block stack size == 1, was {}", lexicalBlockStack.size());
+  MUST_HOLD(mFunctionSymbol != nullptr, "To parse symbol information for a function, there must exist symbol information to parse.");
 }
 
 NonNullPtr<Type>

--- a/src/symbolication/dwarf_expressions.h
+++ b/src/symbolication/dwarf_expressions.h
@@ -88,6 +88,10 @@ struct ExprByteCodeInterpreter
   explicit ExprByteCodeInterpreter(int frameLevel, TraceeController &tc, TaskInfo &t,
                                    std::span<const u8> byteStream, std::span<const u8> frameBaseCode) noexcept;
   AddrPtr ComputeFrameBase() noexcept;
+  // Read contents of register, at frame level `mFrameLevel` - if registers hasn't been unwound, or if that register
+  // for some reason could not be determined, returns nullopt.
+  std::optional<u64> GetRegister(u64 number);
+
   u64 Run() noexcept;
 
   int mFrameLevel;

--- a/src/symbolication/type.h
+++ b/src/symbolication/type.h
@@ -215,7 +215,7 @@ public:
   Type(DwarfTag debugInfoEntryTag, dw::IndexedDieReference debugInfoEntryReference, u32 sizeOf, std::string_view name) noexcept;
 
   // "Special" types. Like void, Unit. Types with no size - and most importantly, no DW_AT_type attr in the DIE.
-  Type(std::string_view name) noexcept;
+  Type(std::string_view name, size_t size=0) noexcept;
   Type(Type &&o) noexcept;
 
   // Resolves the alias that this type def/using decl actually is, if it is one. If it's a concrete type, return itself.

--- a/src/symbolication/value.cpp
+++ b/src/symbolication/value.cpp
@@ -1,4 +1,5 @@
 #include "value.h"
+#include "common.h"
 #include "symbolication/dwarf_expressions.h"
 #include "type.h"
 #include "value_visualizer.h"
@@ -193,9 +194,17 @@ MemoryContentsObject::ReadMemory(TraceeController &tc, AddrPtr address, u32 size
 }
 
 /*static*/
+MemoryContentsObject::ReadResult
+MemoryContentsObject::ReadMemory(std::pmr::memory_resource *allocator, TraceeController &tc, AddrPtr address,
+                                 u32 size_of) noexcept
+{
+  TODO("implement MemoryContentsObject that uses custom allocation strategies.");
+}
+
+/*static*/
 SharedPtr<Value>
 MemoryContentsObject::CreateFrameVariable(TraceeController &tc, NonNullPtr<TaskInfo> task,
-                                            NonNullPtr<sym::Frame> frame, Symbol &symbol, bool lazy) noexcept
+                                          NonNullPtr<sym::Frame> frame, Symbol &symbol, bool lazy) noexcept
 {
   const auto requested_byte_size = symbol.mType->Size();
 
@@ -207,8 +216,8 @@ MemoryContentsObject::CreateFrameVariable(TraceeController &tc, NonNullPtr<TaskI
       TODO("Add support for situations where we can't actually construct the value");
       return nullptr;
     }
-    auto interp =
-      ExprByteCodeInterpreter{frame->FrameLevel(), tc, task, symbol.mLocation->dwarf_expr, fnSymbol->GetFrameBaseDwarfExpression()};
+    auto interp = ExprByteCodeInterpreter{frame->FrameLevel(), tc, task, symbol.mLocation->dwarf_expr,
+                                          fnSymbol->GetFrameBaseDwarfExpression()};
     const auto address = interp.Run();
     if (lazy) {
       auto memory_object = std::make_shared<LazyMemoryContentsObject>(tc, address, address + requested_byte_size);
@@ -236,4 +245,13 @@ MemoryContentsObject::CreateFrameVariable(TraceeController &tc, NonNullPtr<TaskI
   return nullptr;
 }
 
+/*static*/
+Value *
+MemoryContentsObject::CreateFrameVariable(std::pmr::memory_resource *allocator, TraceeController &tc,
+                                          NonNullPtr<TaskInfo> task, NonNullPtr<sym::Frame> frame, Symbol &symbol,
+                                          bool lazy) noexcept
+{
+  TODO_IGNORE_WARN("Unimplemented", allocator, tc, task, frame, symbol, lazy);
+  return nullptr;
+}
 } // namespace sym

--- a/src/tracee/util.cpp
+++ b/src/tracee/util.cpp
@@ -7,30 +7,31 @@
 #include <sys/user.h>
 #include <sys/wait.h>
 
-u32 SystemVectorExtensionSize() noexcept {
+u32
+SystemVectorExtensionSize() noexcept
+{
 #if defined(__GNUC__) || defined(__clang__)
-    if (__builtin_cpu_supports("avx512f")) {
-        return 64; // AVX-512: 512 bits = 64 bytes
-    }
-    if (__builtin_cpu_supports("avx2")) {
-        return 32; // AVX2: 256 bits = 32 bytes
-    }
-    if (__builtin_cpu_supports("avx")) {
-        return 16; // AVX/SSE: 128 bits = 16 bytes
-    }
+  if (__builtin_cpu_supports("avx512f")) {
+    return 64; // AVX-512: 512 bits = 64 bytes
+  }
+  if (__builtin_cpu_supports("avx2")) {
+    return 32; // AVX2: 256 bits = 32 bytes
+  }
+  if (__builtin_cpu_supports("avx")) {
+    return 16; // AVX/SSE: 128 bits = 16 bytes
+  }
 #elif defined(_MSC_VER)
-    int cpuInfo[4] = {};
-    __cpuid(cpuInfo, 1); // Get processor info
-    if (cpuInfo[1] & (1 << 16)) { // Check AVX
-        if (cpuInfo[1] & (1 << 28)) { // Check AVX2
-            // For AVX-512, further checks may be needed for individual features
-            return 64; // Assume AVX-512 support
-        }
-        return 32; // AVX2 supported
+  int cpuInfo[4] = {};
+  __cpuid(cpuInfo, 1);            // Get processor info
+  if (cpuInfo[1] & (1 << 16)) {   // Check AVX
+    if (cpuInfo[1] & (1 << 28)) { // Check AVX2
+      return 64; // Assume AVX-512 support
     }
-    return 16; // Default to AVX/SSE/MMX
+    return 32; // AVX2 supported
+  }
+  return 16; // Default to AVX/SSE/MMX
 #endif
-    return 16; // Fallback: Assume 128 bits = 16 bytes
+  return 16; // Fallback: Assume 128 bits = 16 bytes
 }
 
 static constexpr std::string_view reg_names[17] = {"rax", "rdx", "rcx", "rbx", "rsi", "rdi", "rbp", "rsp", "r8",
@@ -80,4 +81,13 @@ process_exe_path(Pid pid) noexcept
   }
 
   return std::string{resolved};
+}
+
+// N.B. Currently does nothing. In the future will be used to be able to assert in debug mode that specific
+// functionality is sure to be executed only by the main thread.
+std::thread::id
+GetMainThreadId() noexcept
+{
+  static std::thread::id gMainThreadId = std::this_thread::get_id();
+  return gMainThreadId;
 }

--- a/src/tracee/util.h
+++ b/src/tracee/util.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <string>
 #include <typedefs.h>
+#include <thread>
 
 struct user_regs_struct;
 
@@ -10,3 +11,5 @@ u64 get_register(user_regs_struct *regs, int reg_number) noexcept;
 std::string process_exe_path(Pid pid) noexcept;
 
 u32 SystemVectorExtensionSize() noexcept;
+
+std::thread::id GetMainThreadId() noexcept;

--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -168,9 +168,9 @@ void
 Tracer::handle_command(ui::UICommand *cmd) noexcept
 {
   DBGLOG(core, "accepted command {}", cmd->name());
-  auto result = cmd->execute();
+  auto result = cmd->Execute();
 
-  auto data = result->serialize(0);
+  auto data = result->Serialize(0);
   if (!data.empty()) {
     cmd->dap_client->write(data);
   }

--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -1,6 +1,7 @@
 #include "tracer.h"
 #include "interface/dap/dap_defs.h"
 #include "interface/dap/events.h"
+#include <lib/arena_allocator.h>
 #include "interface/pty.h"
 #include "interface/remotegdb/connection.h"
 #include "interface/tracee_command/ptrace_commander.h"
@@ -170,7 +171,9 @@ Tracer::handle_command(ui::UICommand *cmd) noexcept
   DBGLOG(core, "accepted command {}", cmd->name());
   auto result = cmd->Execute();
 
-  auto data = result->Serialize(0);
+  auto scoped = cmd->dap_client->GetResponseArenaAllocator()->ScopeAllocation();
+  ASSERT(scoped.GetAllocator() != nullptr, "Arena allocator could not be retrieved");
+  auto data = result->Serialize(0, scoped.GetAllocator());
   if (!data.empty()) {
     cmd->dap_client->write(data);
   }
@@ -510,7 +513,7 @@ Tracer::new_supervisor(std::unique_ptr<TraceeController> &&tc) noexcept
 }
 
 void
-Tracer::launch(ui::dap::DebugAdapterClient *client, bool stopOnEntry, Path program,
+Tracer::launch(ui::dap::DebugAdapterClient *client, bool stopOnEntry, const Path& program,
                std::span<const std::string> prog_args) noexcept
 {
   termios original_tty;

--- a/src/tracer.h
+++ b/src/tracer.h
@@ -121,7 +121,7 @@ public:
    * hang. */
   void accept_command(ui::UICommand *cmd) noexcept;
   TraceeController *new_supervisor(std::unique_ptr<TraceeController> &&tc) noexcept;
-  void launch(ui::dap::DebugAdapterClient *client, bool stopAtEntry, Path program,
+  void launch(ui::dap::DebugAdapterClient *client, bool stopAtEntry, const Path& program,
               std::span<const std::string> prog_args) noexcept;
   bool attach(const AttachArgs &args) noexcept;
   bool remote_attach_init(tc::GdbRemoteCommander &tc) noexcept;

--- a/src/utils/byte_buffer.cpp
+++ b/src/utils/byte_buffer.cpp
@@ -3,8 +3,15 @@
 
 namespace utils {
 
+constexpr ByteBuffer::ByteBuffer(std::pmr::memory_resource *allocator, u32 cap) noexcept
+    : capacity(cap), mAllocator(allocator)
+{
+  buffer = (u8 *)mAllocator->allocate(cap, 32);
+  value_size = 0;
+}
+
 constexpr ByteBuffer::ByteBuffer(std::uint8_t *buffer, u32 cap) noexcept
-    : buffer(buffer), value_size(0), capacity(cap)
+    : buffer(buffer), value_size(0), capacity(cap), mAllocator(nullptr)
 {
 }
 
@@ -47,4 +54,12 @@ ByteBuffer::create(u64 size) noexcept
   auto ptr = new u8[size];
   return std::make_unique<ByteBuffer>(ptr, size);
 }
+
+/*static*/
+std::unique_ptr<ByteBuffer>
+ByteBuffer::create(std::pmr::memory_resource *allocator, u64 size) noexcept
+{
+  return std::make_unique<ByteBuffer>(allocator, size);
+}
+
 } // namespace utils

--- a/src/utils/byte_buffer.h
+++ b/src/utils/byte_buffer.h
@@ -2,6 +2,7 @@
 #include "macros.h"
 #include <cstdint>
 #include <memory>
+#include <memory_resource>
 #include <span>
 #include <typedefs.h>
 
@@ -20,14 +21,18 @@ private:
   u8 *buffer;
   u32 value_size;
   u32 capacity;
+  std::pmr::memory_resource* mAllocator;
 
 public:
+  constexpr ByteBuffer(std::pmr::memory_resource* allocator, u32 cap) noexcept;
   constexpr ByteBuffer(std::uint8_t *buffer, u32 cap) noexcept;
 
   constexpr ~ByteBuffer() noexcept
   {
-    if (buffer) {
+    if (buffer && !mAllocator) {
       delete[] buffer;
+    } else {
+      mAllocator->deallocate(buffer, capacity);
     }
   }
 
@@ -37,5 +42,6 @@ public:
   u8 *next() noexcept;
   std::span<u8> span() const noexcept;
   static ByteBuffer::OwnPtr create(u64 size) noexcept;
+  static ByteBuffer::OwnPtr create(std::pmr::memory_resource* allocator, u64 size) noexcept;
 };
 } // namespace utils

--- a/src/utils/macros.h
+++ b/src/utils/macros.h
@@ -7,7 +7,9 @@
 #define MIDAS_UNREACHABLE __builtin_unreachable();
 #endif
 
-#define NEVER(msg) PANIC(msg); MIDAS_UNREACHABLE
+#define NEVER(msg)                                                                                                \
+  PANIC(msg);                                                                                                     \
+  MIDAS_UNREACHABLE
 
 #ifndef USING_SMART_PTRS
 #define USING_SMART_PTRS(CLASS)                                                                                   \
@@ -24,6 +26,14 @@
   CLASS &operator=(CLASS &) = delete;                                                                             \
   CLASS &operator=(const CLASS &) = delete;                                                                       \
   USING_SMART_PTRS(CLASS)
+#endif
+
+#ifndef MOVE_ONLY
+#define MOVE_ONLY(CLASS)                                                                                          \
+  CLASS(const CLASS &) = delete;                                                                                  \
+  CLASS(CLASS &) = delete;                                                                                        \
+  CLASS &operator=(CLASS &) = delete;                                                                             \
+  CLASS &operator=(const CLASS &) = delete;
 #endif
 
 #ifndef NO_NON_EXPLICIT_CTORS

--- a/src/utils/scope_defer.h
+++ b/src/utils/scope_defer.h
@@ -1,11 +1,23 @@
 #pragma once
+#include "utils/macros.h"
 #include <utility>
 
 template <typename DeferFn> class ScopedDefer
 {
 public:
+  MOVE_ONLY(ScopedDefer);
   explicit ScopedDefer(DeferFn &&fn) noexcept : defer_fn(std::move(fn)) {}
   ~ScopedDefer() noexcept { defer_fn(); }
+
+  ScopedDefer(ScopedDefer &&other) noexcept : defer_fn(std::move(other.defer_fn)) {}
+  ScopedDefer &
+  operator=(ScopedDefer &&other) noexcept
+  {
+    if (this != &other) {
+      defer_fn = std::move(other.defer_fn);
+    }
+    return *this;
+  }
 
 private:
   DeferFn defer_fn;

--- a/test/driver/stacktraceRequest.js
+++ b/test/driver/stacktraceRequest.js
@@ -107,8 +107,7 @@ async function insidePrologueTest(DA) {
     }
     assert(
       application_frames == 3,
-      `We're exactly at the start of the first instruction of main - expecting only 3 frame but got ${
-        stackFrames.length
+      `We're exactly at the start of the first instruction of main - expecting only 3 frame but got ${stackFrames.length
       }: ${JSON.stringify(stackFrames)}`
     )
     return stackFrames
@@ -136,8 +135,7 @@ async function insideEpilogueTest(DA) {
     assert(
       application_frames == 3,
       () =>
-        `We're exactly at the start of the first instruction of main - expecting only 3 frame but got ${
-          stackFrames.length
+        `We're exactly at the start of the first instruction of main - expecting only 3 frame but got ${stackFrames.length
         }: ${JSON.stringify(stackFrames)}`
     )
     return stackFrames
@@ -147,43 +145,39 @@ async function insideEpilogueTest(DA) {
   verifyFrameIs(frames[2], 'main')
 }
 
+function createExpectedStacktraces(debugAdapter) {
+  const sourceFileContents = readFileContents(repoDirFile('test/stackframes.cpp'))
+
+  const callstack = (idents) =>
+    idents.map((ident) => getLineOf(sourceFileContents, ident))
+      .filter((item) => item != null)
+      .map((l) => ({ line: l }));
+  const checks = ['A', 'B', 'C', 'D'];
+  const [callstackA, callstackB, callstackC, callstackD] =
+    [2, 3, 4, 5]
+      .map((num, checkIndex) =>
+        new Array(num)
+          .fill(0)
+          .map((_, index) => `${checks[checkIndex]}${index + 1}`))
+      .map(stack => callstack(stack))
+  const names = [
+    'quux',
+    'baz',
+    'bar',
+    'foo',
+    'main'
+  ];
+
+  // the C/ELF/posix runtime usually have 3 frames above the main function, the first one being _start.
+  const libcStack = [{ line: 0, name: '*' }, { line: 0, name: '*' }, { line: 0, name: '_start' }];
+
+  return [callstackA, callstackB, callstackC, callstackD].map(stack =>
+    stack.map((item, index) => ({ line: item.line, name: names.slice(names.length - stack.length)[index] })).concat(libcStack)
+  )
+}
+
 async function normalTest(DA) {
-  const expectedStackTraces = [
-    [
-      { line: 48 + 4, name: 'foo' },
-      { line: 55 + 4, name: 'main' },
-      { line: 0, name: '*' },
-      { line: 0, name: '*' },
-      { line: 0, name: '_start' },
-    ],
-    [
-      { line: 42 + 4, name: 'bar' },
-      { line: 49 + 4, name: 'foo' },
-      { line: 55 + 4, name: 'main' },
-      { line: 0, name: '*' },
-      { line: 0, name: '*' },
-      { line: 0, name: '_start' },
-    ],
-    [
-      { line: 23 + 1, name: 'baz' },
-      { line: 43 + 4, name: 'bar' },
-      { line: 49 + 4, name: 'foo' },
-      { line: 55 + 4, name: 'main' },
-      { line: 0, name: '*' },
-      { line: 0, name: '*' },
-      { line: 0, name: '_start' },
-    ],
-    [
-      { line: 16 + 1, name: 'quux' },
-      { line: 25 + 1, name: 'baz' },
-      { line: 43 + 4, name: 'bar' },
-      { line: 49 + 4, name: 'foo' },
-      { line: 55 + 4, name: 'main' },
-      { line: 0, name: '*' },
-      { line: 0, name: '*' },
-      { line: 0, name: '_start' },
-    ],
-  ]
+  const expectedStackTraces = createExpectedStacktraces(DA);
 
   await DA.startRunToMain(DA.buildDirFile('stackframes'), [], seconds(1))
   const file = readFileContents(repoDirFile('test/stackframes.cpp'))
@@ -210,8 +204,7 @@ async function normalTest(DA) {
     assert(
       frames.length == 4,
       () =>
-        `We're exactly at the start of the first instruction of main - expecting only 1 frame but got ${
-          stackFrames.length
+        `We're exactly at the start of the first instruction of main - expecting only 1 frame but got ${stackFrames.length
         }: ${prettyJson(stackFrames)}`
     )
 
@@ -237,8 +230,7 @@ async function normalTest(DA) {
         assert(
           stackFrames[idx].line == expectedStackTraces[i - total][idx].line,
           () =>
-            `Expected line to be at ${expectedStackTraces[i - total][idx].line} but was ${
-              stackFrames[idx].line
+            `Expected line to be at ${expectedStackTraces[i - total][idx].line} but was ${stackFrames[idx].line
             }: ${prettyJson(stackFrames)}`
         )
         if (
@@ -247,8 +239,7 @@ async function normalTest(DA) {
         ) {
           assert(
             false,
-            `Expected name to be ${expectedStackTraces[i - total][idx].name} but was ${
-              stackFrames[idx].name
+            `Expected name to be ${expectedStackTraces[i - total][idx].name} but was ${stackFrames[idx].name
             }: ${prettyJson(stackFrames)}`
           )
         }

--- a/test/stackframes.cpp
+++ b/test/stackframes.cpp
@@ -37,16 +37,16 @@ int fibonacci(int n) {
 static int
 quux(int acc, int a)
 {
-  return acc * a; // BP4
+  return acc * a; // BP4 D1
 }
 
 static int
 baz(int a, int b, int times)
 {
   int res_a = 1; // BPLine1
-  int res_b = 1; // BP3
+  int res_b = 1; // BP3 C1
   while (times > 0) {
-    res_a = quux(res_a, a);
+    res_a = quux(res_a, a); // D2
     res_b = quux(res_b, b);
     int fibOfTimes = fibonacci(times);
     int test = fib(times);
@@ -70,19 +70,19 @@ raise_after_baz(int a, int b)
 static void
 bar(int a, int b)
 {
-  baz(a, b, 4); // BP2
-}
+  baz(a, b, 4); // BP2 B1
+} // C2 D3
 
 static void
 foo()
 {
-  bar(1, 2); // BP1
-}
+  bar(1, 2); // BP1 A1
+} // B2 C3 D4
 
 int
 main(int argc, const char **argv)
 {
   foo();
-  Bar bar{.foo = Foo{.foo_value = 1}, .bar_value = 2};
+  Bar bar{.foo = Foo{.foo_value = 1}, .bar_value = 2}; // A2 B3 C4 D5
   return -15;
 }


### PR DESCRIPTION
# Introduced the first (of probably many) custom allocators to the project.

This is a trivial addition; for `Serialize` methods for the debug adapter protocol commands, take an additional parameter now `std::pmr::memory_resource*` which provides the memory. 

## Future work
Note that, things like `std::pmr::string` still has to `.reserve`, otherwise it will keep doing it's "re allocate with 1.5 when full", which although the allocators provide a way to just "forget all allocations made by the function" when it's done, still re allocates stuff inside the function, doing unnecessary work. In the future, we'll specialize the std::pmr::memory_resource*, as well write our own string builder class that uses the specialised memory resource, so that we can do 

```cpp
mdb::string str{allocator};
str.reserve(4); // reserves 4 bytes
str.push("abcd"); // filled up space
str.push_back('e'); // instead of reallocating 8 bytes, copy over abcd, we now, with our specialized allocator, just lets the current string allocation continue on. 
```

This would entail writing an arena allocator that knows when it handed out memory to a string builder and if some other type requests memory, it offsets it by some fixed amount, or just manages an internal pool; one for string building, one for the rest

And when the command/job is done, all allocations are just ripped out/reset the allocator offsets to 0.