### PR TITLE
Substantial commit (unreviewable)

### DIFF
--- a/src/interface/dap/interface.cpp
+++ b/src/interface/dap/interface.cpp
@@ -115,7 +115,7 @@ DAP::DAP(Tracer *tracer, int tracer_input_fd, int tracer_output_fd) noexcept
   posted_evt_listener = r;
   tracee_stdout_buffer = mmap_buffer<char>(4096 * 3);
   sources.push_back({new_client_notifier.read.fd, InterfaceNotificationSource::NewClient, nullptr});
-  mTemporaryArena = ArenaAllocator::Create(utils::SystemPagesInBytes(16), nullptr);
+  mTemporaryArena = alloc::ArenaAllocator::Create(alloc::Page{16}, nullptr);
 }
 
 DAP::~DAP() noexcept {}
@@ -329,10 +329,13 @@ DAP::configure_tty(int master_pty_fd) noexcept
 void
 DebugAdapterClient::InitAllocators() noexcept
 {
+  using alloc::Page;
+  using alloc::ArenaAllocator;
+
   // Create a 1 megabyte arena allocator.
-  mCommandsAllocator = ArenaAllocator::Create(utils::SystemPagesInBytes(16), nullptr);
-  mCommandResponseAllocator = ArenaAllocator::Create(utils::SystemPagesInBytes(8), nullptr);
-  mEventsAllocator = ArenaAllocator::Create(utils::SystemPagesInBytes(16), nullptr);
+  mCommandsAllocator = ArenaAllocator::Create(Page{16}, nullptr);
+  mCommandResponseAllocator = ArenaAllocator::Create(Page{8}, nullptr);
+  mEventsAllocator = ArenaAllocator::Create(Page{16}, nullptr);
 }
 
 DebugAdapterClient::DebugAdapterClient(DapClientSession type, std::filesystem::path &&path, int socket) noexcept
@@ -414,13 +417,13 @@ DebugAdapterClient::createSocketConnection(DebugAdapterClient *client) noexcept
   }
 }
 
-ArenaAllocator *
+alloc::ArenaAllocator *
 DebugAdapterClient::GetCommandArenaAllocator() noexcept
 {
   return mCommandsAllocator.get();
 }
 
-ArenaAllocator *
+alloc::ArenaAllocator *
 DebugAdapterClient::GetResponseArenaAllocator() noexcept
 {
   return mCommandResponseAllocator.get();

--- a/src/interface/dap/interface.h
+++ b/src/interface/dap/interface.h
@@ -14,8 +14,10 @@
 class Tracer;
 class TraceeController;
 /* The different DAP commands/requests */
+namespace alloc {
+  class ArenaAllocator;
+}
 
-class ArenaAllocator;
 
 namespace ui {
 struct UIResult;
@@ -143,9 +145,9 @@ class DebugAdapterClient
   // The allocator that can be used by commands during execution of them, for temporary objects etc
   // UICommand upon destruction, calls mCommandsAllocator.Reset(), at which point all allocations beautifully melt
   // away.
-  std::unique_ptr<ArenaAllocator> mCommandsAllocator;
-  std::unique_ptr<ArenaAllocator> mCommandResponseAllocator;
-  std::unique_ptr<ArenaAllocator> mEventsAllocator;
+  std::unique_ptr<alloc::ArenaAllocator> mCommandsAllocator;
+  std::unique_ptr<alloc::ArenaAllocator> mCommandResponseAllocator;
+  std::unique_ptr<alloc::ArenaAllocator> mEventsAllocator;
 
   DebugAdapterClient(DapClientSession session, std::filesystem::path &&path, int socket_fd) noexcept;
   // Most likely used as the initial DA Client Connection (which tends to be via standard in/out, but don't have to
@@ -161,8 +163,8 @@ public:
   DapClientSession session_type;
   ~DebugAdapterClient() noexcept;
 
-  ArenaAllocator* GetCommandArenaAllocator() noexcept;
-  ArenaAllocator* GetResponseArenaAllocator() noexcept;
+  alloc::ArenaAllocator* GetCommandArenaAllocator() noexcept;
+  alloc::ArenaAllocator* GetResponseArenaAllocator() noexcept;
   static DebugAdapterClient *createStandardIOConnection() noexcept;
   static DebugAdapterClient *createSocketConnection(DebugAdapterClient *client) noexcept;
   void client_configured(TraceeController *tc) noexcept;
@@ -193,7 +195,7 @@ class DAP
 private:
   std::vector<utils::OwningPointer<DebugAdapterClient>> clients{};
   std::vector<NotifSource> sources{};
-  std::unique_ptr<ArenaAllocator> mTemporaryArena;
+  std::unique_ptr<alloc::ArenaAllocator> mTemporaryArena;
 
 public:
   explicit DAP(Tracer *tracer, int tracer_input_fd, int tracer_output_fd) noexcept;

--- a/src/interface/ui_command.h
+++ b/src/interface/ui_command.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <string_view>
 #include <vector>
+#include <chrono>
 
 class Tracer;
 class TraceeController;
@@ -100,6 +101,8 @@ public:
   /* Executes the command. This is always performed in the Tracer thread (where all tracee controller actions are
    * performed. )*/
   virtual UIResultPtr Execute() noexcept = 0;
+
+  UIResultPtr LogExecute() noexcept;
 
   template <typename Derived, typename JsonArgs>
   static constexpr MissingOrInvalidResult

--- a/src/lib/vector.h
+++ b/src/lib/vector.h
@@ -1,0 +1,78 @@
+#pragma once
+#include "lib/arena_allocator.h"
+#include "utils/util.h"
+#include <cstddef>
+#include <cstdint>
+#include <memory_resource>
+
+namespace alloc {
+  class ArenaAllocator;
+}
+
+namespace mdb {
+
+using u32 = std::uint32_t;
+using u64 = std::uint64_t;
+
+template <typename T, std::size_t InlineSize> class SBOVector
+{
+  T mInlined[InlineSize];
+
+public:
+  explicit SBOVector() noexcept;
+};
+
+// A "normal" std::vector-like vector. Only it uses allocators,
+// and comes with a better (in my opinion) interface. Because we choose u32/u32 as size and cap, instead of u64, we
+// maintain the same size as std::vector, but with better allocator customization
+template <typename T> class Vector
+{
+  T *mPtr;
+  u32 mSize{0};
+  u32 mCapacity;
+  std::pmr::memory_resource *mAllocator;
+
+public:
+  Vector(u32 capacity) noexcept : mPtr(mAllocator->allocate(sizeof(T) * capacity, 64)), mCapacity(capacity) {}
+  void Push(T&& t) noexcept {}
+};
+
+template <typename T>
+class Array {
+  T* mPtr;
+  u64 mSize;
+public:
+  Array(T* finalizedBuffer, u64 size) : mPtr(finalizedBuffer), mSize(size) {}
+
+  auto begin() noexcept {
+    return mPtr;
+  }
+
+  auto end() noexcept {
+    return mPtr + mSize;
+  }
+};
+
+/** CollectionBuilder takes an arena allocator that can allocate new pages consecutively to previous ones - this makes
+* this allocator great to use with this "collection builder" which is sort of meant to be as a temporary std::vector that "finalizes" an array.
+* and because our AA can re-alloc it's internal buffer contigously, the CollectionBuilder can keep push-backing, re-alloc, push back, re alloc,
+* without having to copy over it's old elements. */
+template<typename T>
+class CollectionBuilder {
+  alloc::ArenaAllocator* mAllocator;
+  T* mPtr;
+  u32 mCurrentSize;
+  u32 mCurrentCapacity;
+public:
+  explicit CollectionBuilder(alloc::ArenaAllocator* alloc) noexcept : mAllocator(alloc) {
+  }
+
+  template <typename ...Args>
+  T& Emplace(Args&&... args) {
+    if(mCurrentSize == mCurrentCapacity) {
+      mAllocator->allocate()
+    }
+  }
+};
+
+} // namespace mdb

--- a/src/log.h
+++ b/src/log.h
@@ -1,0 +1,24 @@
+#pragma once
+
+namespace mdb {
+namespace log {
+
+class Config
+{
+public:
+  static bool &
+  LogTaskGroup()
+  {
+    static bool globalLogTaskGroup = true; // Lazily initialized global bool
+    return globalLogTaskGroup;
+  }
+
+  static void
+  SetLogTaskGroup(bool configure = true)
+  {
+    LogTaskGroup() = configure;
+  }
+};
+
+}; // namespace log
+} // namespace mdb

--- a/src/mdb_config.cpp
+++ b/src/mdb_config.cpp
@@ -1,6 +1,7 @@
 #include "mdb_config.h"
 #include "fmt/core.h"
 #include "fmt/ranges.h"
+#include "log.h"
 #include "utils/logger.h"
 #include "utils/util.h"
 #include "utils/worker_task.h"
@@ -32,7 +33,7 @@ parse_int(std::string_view str)
 void
 LogConfig::configure_logging(bool taskgroup_log) noexcept
 {
-  SetTaskGroupLog(taskgroup_log);
+  mdb::log::Config::SetLogTaskGroup(taskgroup_log);
 }
 
 WaitSystem

--- a/src/symbolication/cu_symbol_info.h
+++ b/src/symbolication/cu_symbol_info.h
@@ -66,7 +66,7 @@ public:
   }
 
 private:
-  void resolve_fn_symbols() noexcept;
+  void PrepareFunctionSymbols() noexcept;
 };
 
 class AddressToCompilationUnitMap

--- a/src/symbolication/dwarf.h
+++ b/src/symbolication/dwarf.h
@@ -25,7 +25,7 @@ struct StrSlice
 template <typename T>
 concept AttributeValueType =
   std::is_same_v<T, u64> || std::is_same_v<T, i64> || std::is_same_v<T, DataBlock> ||
-  std::is_same_v<T, StrSlice> || std::is_same_v<T, std::string_view> || std::is_same_v<T, AddrPtr>;
+  std::is_same_v<T, StrSlice> || std::is_same_v<T, std::string_view> || std::is_same_v<T, AddrPtr> || std::is_same_v<T, const char*>;
 
 /** Fully-formed attribtue */
 struct AttributeValue
@@ -67,11 +67,16 @@ struct AttributeValue
   {
     return value.addr;
   }
+
+  const char*
+  string() const noexcept { return value.str; }
+
   std::string_view
-  string() const noexcept
+  string_view() const noexcept
   {
     return value.str;
   }
+
   DataBlock
   block() const noexcept
   {
@@ -112,7 +117,7 @@ struct AttributeValue
 private:
   union _value
   { // Size = 16 bytes
-    constexpr _value(std::string_view str) noexcept : str{str} {}
+    constexpr _value(const char* str) noexcept : str{str} {}
     constexpr _value(DataBlock block) noexcept : block(block) {}
     constexpr _value(u64 u) noexcept : u(u) {}
     constexpr _value(i64 i) noexcept : i(i) {}
@@ -136,7 +141,7 @@ private:
 
     DataBlock block;
     // StrSlice str;
-    std::string_view str;
+    const char* str;
     u64 u;
     i64 i;
     AddrPtr addr;

--- a/src/symbolication/dwarf/attribute_read.h
+++ b/src/symbolication/dwarf/attribute_read.h
@@ -16,7 +16,7 @@ read_attributes(UnitData *unitData, const DieMetaData &die, std::array<Attribute
   std::array<std::optional<AttributeValue>, N> result;
   UnitReader reader{unitData};
   const auto &attrs = unitData->get_abbreviation(die.abbreviation_code);
-  reader.seek_die(die);
+  reader.SeekDie(die);
 
   for (auto attribute : attrs.attributes) {
     for (auto i = 0; i < attributes.size(); ++i) {
@@ -52,7 +52,7 @@ ProcessDie(DieReference dieRef, Fn &&fn) noexcept
   ASSERT(unit && die, "Compilation Unit required to be not-null");
   UnitReader reader{unit};
   const auto &attrs = unit->get_abbreviation(die->abbreviation_code);
-  reader.seek_die(*die);
+  reader.SeekDie(*die);
   for (auto attribute : attrs.attributes) {
     switch (fn(reader, attribute, attrs)) {
     case DieAttributeRead::Continue:

--- a/src/symbolication/dwarf/debug_info_reader.h
+++ b/src/symbolication/dwarf/debug_info_reader.h
@@ -20,13 +20,15 @@ class UnitReader
 public:
   explicit UnitReader(UnitData *data) noexcept;
   UnitReader(UnitData *data, const DieMetaData &entry) noexcept;
-  UnitReader(const UnitReader &o);
-  UnitReader &operator=(const UnitReader &reader);
+  UnitReader(UnitData *data, u64 offset) noexcept;
+  UnitReader(const UnitReader &o) noexcept;
+  UnitReader &operator=(const UnitReader &reader) noexcept;
 
   void skip_attributes(const std::span<const Abbreviation> &attributes) noexcept;
   void skip_attribute(const Abbreviation &abbreviation) noexcept;
   AddrPtr read_address() noexcept;
   std::string_view read_string() noexcept;
+  const char *ReadCString() noexcept;
   DataBlock read_block(u64 block_size) noexcept;
   u64 bytes_read() const noexcept;
 
@@ -39,14 +41,15 @@ public:
   u64 read_section_offset(u64 offset) const noexcept;
   u64 read_n_bytes(u8 n_bytes) noexcept;
   AddrPtr read_by_idx_from_addr_table(u64 address_index) const noexcept;
-  std::string_view read_by_idx_from_str_table(u64 str_index) const noexcept;
+  const char *read_by_idx_from_str_table(u64 str_index) const noexcept;
   u64 read_by_idx_from_rnglist(u64 range_index) const noexcept;
   u64 read_loclist_index(u64 range_index, std::optional<u64> loc_list_base) const noexcept;
   u64 sec_offset() const noexcept;
   bool has_more() const noexcept;
 
   /* Set UnitReader to start reading the data for `entry` */
-  void seek_die(const DieMetaData &entry) noexcept;
+  void SeekDie(const DieMetaData &entry) noexcept;
+  void SetOffset(u64 offset) noexcept;
   ObjectFile *objfile() const noexcept;
   const Elf *elf() const noexcept;
   const u8 *ptr() const noexcept;
@@ -69,8 +72,21 @@ public:
   }
 
 private:
+  inline constexpr u64
+  Format() const noexcept
+  {
+    return mFormat;
+  }
+
+  inline constexpr u64
+  AddressSize() const noexcept
+  {
+    return 8;
+  }
+
   UnitData *compilation_unit;
   const u8 *current_ptr;
+  u8 mFormat;
 };
 
 AttributeValue read_attribute_value(UnitReader &reader, Abbreviation abbr,

--- a/src/symbolication/dwarf/die_ref.h
+++ b/src/symbolication/dwarf/die_ref.h
@@ -9,6 +9,7 @@ namespace sym::dw {
 class UnitData;
 struct DieMetaData;
 class UnitReader;
+class AbbreviationInfo;
 
 /**
  * Reads the following data from the unit die for the compilation unit `compilationUnit`:
@@ -26,13 +27,15 @@ class DieReference
 protected:
   UnitData *mUnitData;
   const DieMetaData *mDebugInfoEntry;
-
 public:
+  DieReference() noexcept = default;
   DieReference(UnitData *compilationUnit, const DieMetaData *die) noexcept;
   UnitData *GetUnitData() const noexcept;
   const DieMetaData *GetDie() const noexcept;
   DieReference MaybeResolveReference() const noexcept;
-  Index IndexOfDie() const noexcept;
+  u64 IndexOfDie() const noexcept;
+
+  const AbbreviationInfo & GetAbbreviation() const noexcept;
 
   bool IsValid() const noexcept;
   IndexedDieReference AsIndexed() const noexcept;
@@ -43,16 +46,16 @@ public:
 class IndexedDieReference
 {
   UnitData *mUnitData;
-  Index mDieIndex;
+  u64 mDieIndex;
 
 public:
   IndexedDieReference() = default;
   explicit IndexedDieReference(const DieReference &reference) noexcept;
-  IndexedDieReference(UnitData *compilationUnit, Index index) noexcept;
+  IndexedDieReference(UnitData *compilationUnit, u64 index) noexcept;
 
   bool IsValid() const noexcept;
   UnitData *GetUnitData() const noexcept;
-  Index GetIndex() const noexcept;
+  u64 GetIndex() const noexcept;
   const DieMetaData *GetDie() noexcept;
 
   friend constexpr auto

--- a/src/symbolication/dwarf/name_index.h
+++ b/src/symbolication/dwarf/name_index.h
@@ -10,10 +10,10 @@ namespace sym::dw {
 
 class UnitData;
 
-struct foo
+struct DieNameRef
 {
   UnitData *cu;
-  u32 die_index;
+  u64 die_index;
 };
 
 struct DieNameReference
@@ -23,7 +23,7 @@ struct DieNameReference
     struct
     {
       UnitData *cu;
-      Index die_index;
+      u64 die_index;
     };
     // Collision variant - if two identical exists, but refer to different DIE's, this DieNameReference signals
     // that
@@ -31,19 +31,18 @@ struct DieNameReference
     {
       u64 collision_displacement_index; // where in the collision container, other die references that has the same
                                         // name is stored at (`non_unique_names` in `NameIndex`)
-      u32 unique; // unique is true iff unique != 0xff'ff'ff'ff, meaning, die_index != 0xff'ff'ff'ff
+      u64 unique; // unique is true iff unique != 0xff'ff'ff'ff, meaning, die_index != 0xff'ff'ff'ff
     };
   };
 
   DieNameReference() noexcept : cu(nullptr), die_index(0) {}
-  DieNameReference(UnitData *cu, u32 die_index) noexcept : cu(cu), die_index(die_index) {}
-  DieNameReference(UnitData *cu, Index die_index) noexcept : cu(cu), die_index(die_index) {}
+  DieNameReference(UnitData *cu, u64 die_index) noexcept : cu(cu), die_index(die_index) {}
 
   bool is_valid() const;
   bool is_unique() const noexcept;
-  void set_as_collision_variant(u32 index) noexcept;
+  void set_as_collision_variant(u64 index) noexcept;
   void set_not_unique() noexcept;
-  void set_collision_index(u32 index) noexcept;
+  void set_collision_index(u64 index) noexcept;
 };
 
 class UnitData;
@@ -51,7 +50,7 @@ class UnitData;
 class NameIndex
 {
 public:
-  using NameDieTuple = std::tuple<std::string_view, Index, UnitData *>;
+  using NameDieTuple = std::tuple<const char*, u64, UnitData *>;
   struct FindResult
   {
     DieNameReference *dies;
@@ -76,8 +75,8 @@ public:
   void merge_types(ObjectFile *objfile, const std::vector<NameDieTuple> &parsed_die_name_references) noexcept;
 
 private:
-  void add_name(std::string_view name, Index die_index, UnitData *cu) noexcept;
-  void convert_to_collision_variant(DieNameReference &elem, Index die_index, UnitData *cu) noexcept;
+  void add_name(const char* name, u64 die_index, UnitData *cu) noexcept;
+  void convert_to_collision_variant(DieNameReference &elem, u64 die_index, UnitData *cu) noexcept;
   // The mutex only guars insert operations, because when the user is going to use query operations (finding a die
   // by it's name) the entire name index should be fully built.
   std::string_view index_name;

--- a/src/symbolication/dwarf/rnglists.cpp
+++ b/src/symbolication/dwarf/rnglists.cpp
@@ -9,7 +9,7 @@ namespace sym::dw {
 /*static*/ ResolvedRangeListOffset
 ResolvedRangeListOffset::make(sym::dw::UnitData &cu, u64 unresolved_offset) noexcept
 {
-  return ResolvedRangeListOffset{cu.rng_list_base() + unresolved_offset};
+  return ResolvedRangeListOffset{cu.RangeListBase() + unresolved_offset};
 }
 
 u32
@@ -77,7 +77,7 @@ read_boundaries(sym::dw::UnitData &cu, ResolvedRangeListOffset resolved) noexcep
     case RangeListEntry::DW_RLE_base_addressx: {
       u64 addr_index = 0;
       ptr = decode_uleb128(ptr, addr_index);
-      const auto addr_ptr = elf->debug_addr->GetPointer(cu.addr_base() + addr_index * 8);
+      const auto addr_ptr = elf->debug_addr->GetPointer(cu.AddressBase() + addr_index * 8);
       u64 start_addr = 0;
       std::memcpy(&start_addr, addr_ptr, 8);
       base = start_addr;
@@ -89,7 +89,7 @@ read_boundaries(sym::dw::UnitData &cu, ResolvedRangeListOffset resolved) noexcep
       ptr = decode_uleb128(ptr, addr_index);
       u64 range_length = 0;
       ptr = decode_uleb128(ptr, range_length);
-      const auto addr_ptr = elf->debug_addr->GetPointer(cu.addr_base() + (addr_index * 8));
+      const auto addr_ptr = elf->debug_addr->GetPointer(cu.AddressBase() + (addr_index * 8));
       u64 start_addr = 0;
       std::memcpy(&start_addr, addr_ptr, 8);
       result.push_back({start_addr, start_addr + range_length});

--- a/src/symbolication/dwarf/typeread.h
+++ b/src/symbolication/dwarf/typeread.h
@@ -34,7 +34,7 @@ class FunctionSymbolicationContext
   void process_formal_param(DieReference cu_die) noexcept;
   void process_variable(DieReference cu_die) noexcept;
   void process_lexical_block(DieReference cu_die) noexcept;
-  void process_inlined(DieReference cu_die) noexcept;
+  void ProcessInlinedSubroutine(DieReference cu_die) noexcept;
   NonNullPtr<Type> process_type(DieReference cu_die) noexcept;
 
 public:

--- a/src/symbolication/dwarf_binary_reader.cpp
+++ b/src/symbolication/dwarf_binary_reader.cpp
@@ -160,10 +160,10 @@ DwarfBinaryReader::read_content_str(AttributeForm form) noexcept
     return read_string();
   case DW_FORM_line_strp:
     ASSERT(elf->debug_line_str != nullptr, "Reading value of form DW_FORM_line_strp requires .debug_line section");
-    return elf->debug_line_str->GetNullTerminatedStringAt(read_offset());
+    return elf->debug_line_str->GetCString(read_offset());
   case DW_FORM_strp:
     ASSERT(elf->debug_str != nullptr, "Reading value of form DW_FORM_strp requires .debug_str section");
-    return elf->debug_str->GetNullTerminatedStringAt(read_offset());
+    return elf->debug_str->GetCString(read_offset());
   case DW_FORM_strp_sup:
   case DW_FORM_strx:
   case DW_FORM_strx1:

--- a/src/symbolication/elf.h
+++ b/src/symbolication/elf.h
@@ -53,7 +53,7 @@ struct ElfSection
   const u8 *begin() const noexcept;
   const u8 *end() const noexcept;
   const u8 *Into(AddrPtr addr) const noexcept;
-  std::string_view GetNullTerminatedStringAt(u64 offset) const noexcept;
+  const char* GetCString(u64 offset) const noexcept;
 
   /**
    * Determines offset of `inside_ptr` from `m_section_ptr`.

--- a/src/symbolication/value.h
+++ b/src/symbolication/value.h
@@ -166,8 +166,7 @@ public:
   // shit in computer time - reading the entire chunk is faster than managing sub parts here and there. Just pull
   // in the whole damn thing while we are still in kernel land. Objects are *RARELY* large enough to justify
   // anythign else.
-  static std::shared_ptr<Value> CreateFrameVariable(TraceeController &tc, NonNullPtr<TaskInfo> task,
-                                                    NonNullPtr<sym::Frame> frame, Symbol &symbol,
+  static std::shared_ptr<Value> CreateFrameVariable(TraceeController &tc, const sym::Frame& frame, Symbol &symbol,
                                                     bool lazy) noexcept;
 
   static Value *CreateFrameVariable(std::pmr::memory_resource *allocator, TraceeController &tc,

--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -169,7 +169,7 @@ void
 Tracer::handle_command(ui::UICommand *cmd) noexcept
 {
   DBGLOG(core, "accepted command {}", cmd->name());
-  auto result = cmd->Execute();
+  auto result = cmd->LogExecute();
 
   auto scoped = cmd->dap_client->GetResponseArenaAllocator()->ScopeAllocation();
   ASSERT(scoped.GetAllocator() != nullptr, "Arena allocator could not be retrieved");

--- a/src/utils/logger.cpp
+++ b/src/utils/logger.cpp
@@ -24,6 +24,8 @@ to_str(Channel id) noexcept
     return "eh";
   case Channel::remote:
     return "remote";
+  case Channel::perf:
+    return "perf";
   case Channel::COUNT:
     PANIC("Count not a valid Id");
     break;

--- a/src/utils/logger.h
+++ b/src/utils/logger.h
@@ -26,6 +26,8 @@ enum class Channel : u32
   eh,
   // Gdb Remote Protocol
   remote,
+  // Performance timing results
+  perf,
 
   // Keep always last. Always.
   COUNT

--- a/src/utils/util.h
+++ b/src/utils/util.h
@@ -4,6 +4,7 @@
 #include <numeric>
 #include <optional>
 #include <string_view>
+#include <type_traits>
 #include <typedefs.h>
 #include <utility>
 #include <vector>
@@ -210,4 +211,11 @@ SystemPagesInBytes(int pageCount) noexcept -> size_t
   return pageCount * PAGE_SIZE;
 }
 
+template <typename T, typename U>
+constexpr bool IsSame() {
+  if constexpr(std::is_same_v<std::remove_cvref_t<T>, std::remove_cvref_t<U>>) {
+    return true;
+  }
+  return false;
+}
 } // namespace utils

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -81,6 +81,11 @@ BuildTestSubject(
 )
 
 BuildTestSubject(
+  NAME pmr
+  SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/pmr.cpp
+)
+
+BuildTestSubject(
   NAME functionBreakpoints
   SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/functionBreakpoints.cpp
 )

--- a/test/pmr.cpp
+++ b/test/pmr.cpp
@@ -1,0 +1,24 @@
+#include <iostream>
+#include <memory_resource>
+#include <format>
+
+int main() {
+  std::array<char, 32> buf;
+  std::pmr::monotonic_buffer_resource rsrc{&buf, std::size(buf), std::pmr::new_delete_resource() };
+  std::pmr::string test{&rsrc};
+  test.reserve(4);
+  test.append("hell");
+  test.append("o world");
+  test.append("what's going on");
+  std::print(std::cout, "data:\t\t 0x{}\n", (void*)test.data());
+  std::print(std::cout, "array data:\t 0x{}\n Now add additional data, and hopefully we get from new and delete\n", (void*)buf.data());
+
+  test.append("this is yet another string, let's see what happens");
+  
+  std::print(std::cout, "data: 0x{}\n", (void*)test.data());
+  std::print(std::cout, "array data: 0x{}\n", (void*)buf.data());
+
+  std::print(std::cout, "array contents: \t '{}'\n", std::string_view{buf.data(), 32});
+
+  return 0;
+}


### PR DESCRIPTION
But it consists of 2 important updates

- Extended the support for ELF executables that are of type "DYN".

- Added support to parse .debug_loc and .debug_loclist so that symbols that use location lists for their location information instead of in-line dwarf expression streams can be understood. These changes are in type.h|cpp, die*.h|cpp, typeread.h|cpp etc. This brings the debugger a lot closer to be able to handle applications that use the broader OS ecosystem (does fancy pants things with how it loads libraries and so on). 

- When searching for DIE's by offset I've now done the long overdue change to the lookup algorithm. Before it just did stupid linear search. But of course, for normal sized applications this won't do, certain compile units may have hundreds of thousands of DIE's and searching by offset in a linear fashion is stupid, but it was something I thought about to worry later. That later was now. Now just use lower_bound/binary search.

