### PR TITLE
Added DebugAdapterProtocolString

### DIFF
--- a/src/interface/console_command.cpp
+++ b/src/interface/console_command.cpp
@@ -45,10 +45,10 @@ ConsoleCommandInterpreter::RegisterConsoleCommand(std::string_view name,
 }
 
 ConsoleCommandResult
-ConsoleCommandInterpreter::Interpret(const std::string &input, std::pmr::memory_resource *allocator) noexcept
+ConsoleCommandInterpreter::Interpret(const std::string &input, Allocator *allocator) noexcept
 {
   auto result = Tracer::GetScriptingInstance().ReplEvaluate(input, allocator);
-  return ConsoleCommandResult{true, std::move(result)};
+  return ConsoleCommandResult{true, result};
 }
 
 GenericCommand::GenericCommand(std::string functionName, Function &&function) noexcept

--- a/src/interface/console_command.h
+++ b/src/interface/console_command.h
@@ -1,5 +1,6 @@
 /** LICENSE TEMPLATE */
 #pragma once
+#include "typedefs.h"
 #include <functional>
 #include <memory>
 #include <memory_resource>
@@ -16,7 +17,7 @@ namespace mdb {
 struct ConsoleCommandResult
 {
   bool mSuccess;
-  std::pmr::string mContents;
+  std::pmr::string *mContents;
 };
 
 // Abstract base class for commands, that are called & evaluated via the `EvaluateRequest` request
@@ -48,7 +49,7 @@ private:
 
 public:
   void RegisterConsoleCommand(std::string_view name, std::shared_ptr<ConsoleCommand> command) noexcept;
-  ConsoleCommandResult Interpret(const std::string &input, std::pmr::memory_resource *allocator) noexcept;
+  ConsoleCommandResult Interpret(const std::string &input, Allocator *allocator) noexcept;
 };
 
 /// Commands that are "generic" and installed via `Tracer::SetupConsoleCommands`

--- a/src/interface/dap/commands.h
+++ b/src/interface/dap/commands.h
@@ -728,12 +728,12 @@ struct Evaluate final : public UICommand
 
 struct EvaluateResponse final : public UIResult
 {
-  EvaluateResponse(bool success, Evaluate *cmd, std::optional<int> variablesReference, std::pmr::string &&result,
+  EvaluateResponse(bool success, Evaluate *cmd, std::optional<int> variablesReference, std::pmr::string *result,
                    std::optional<std::string> &&type, std::optional<std::string> &&memoryReference) noexcept;
   ~EvaluateResponse() noexcept override = default;
   std::pmr::string Serialize(int seq, std::pmr::memory_resource *arenaAllocator) const noexcept final;
 
-  std::pmr::string result;
+  std::pmr::string *result;
   std::optional<std::string> type;
   int variablesReference;
   std::optional<std::string> memoryReference;

--- a/src/interface/dap/interface.cpp
+++ b/src/interface/dap/interface.cpp
@@ -366,8 +366,7 @@ DebugAdapterClient::FlushEvents() noexcept
   }
 
   for (auto evt : std::span{tmp, count}) {
-    auto allocator = mEventsAllocator.get()->ScopeAllocation();
-    auto result = evt->Serialize(0, allocator);
+    auto result = evt->Serialize(0, mEventsAllocator.get());
     WriteSerializedProtocolMessage(result);
     delete evt;
   }

--- a/src/mdbjs/mdbjs.h
+++ b/src/mdbjs/mdbjs.h
@@ -1,6 +1,5 @@
 /** LICENSE TEMPLATE */
 #pragma once
-#include "js/CharacterEncoding.h"
 #include "js/Class.h"
 #include "js/PropertyDescriptor.h"
 #include "js/PropertySpec.h"
@@ -29,6 +28,7 @@ namespace mdb::js {
 // where we instead return some structured data for the exception that happened in js-land.
 // For now, if this returns a non-none value, it means an exception happened (and we consumed it).
 std::optional<std::string> ConsumePendingException(JSContext *context) noexcept;
+bool ConsumePendingException(JSContext *context, std::pmr::string &writeToBuffer) noexcept;
 
 class EventDispatcher;
 
@@ -226,7 +226,7 @@ public:
 
   Expected<JSFunction *, std::string> SourceBreakpointCondition(u32 breakpointId,
                                                                 std::string_view condition) noexcept;
-  std::pmr::string ReplEvaluate(std::string_view input, std::pmr::memory_resource *allocator) noexcept;
+  std::pmr::string *ReplEvaluate(std::string_view input, Allocator *allocator) noexcept;
   std::string ReplEvaluate(std::string_view input) noexcept;
   Expected<void, std::string> EvaluateJavascriptStringView(std::string_view javascriptSource) noexcept;
   Expected<void, std::string> EvaluateJavascriptFileView(std::string_view filePath) noexcept;

--- a/src/symbolication/value_visualizer.cpp
+++ b/src/symbolication/value_visualizer.cpp
@@ -405,7 +405,7 @@ CStringVisualizer::Serialize(const Value &value, std::string_view name, int,
   FormatAndReturn(
     result,
     R"({{ "name": "{}", "value": "{}", "type": "const char *", "variablesReference": {}, "memoryReference": "{}" }})",
-    name, cast, 0, value.Address());
+    name, DAPStringView{cast}, 0, value.Address());
 }
 
 #undef FormatAndReturn

--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -220,7 +220,7 @@ Tracer::ConvertWaitEvent(TaskWaitResult wait_res) noexcept
 }
 
 void
-Tracer::handle_command(ui::UICommand *cmd) noexcept
+Tracer::ExecuteCommand(ui::UICommand *cmd) noexcept
 {
   auto dapClient = cmd->mDAPClient;
   DBGLOG(core, "[{}] accepted command {}",
@@ -297,12 +297,10 @@ Tracer::HandleInitEvent(TraceEvent *evt) noexcept
 #define OK_RESULT(res)                                                                                            \
   ConsoleCommandResult { true, std::move(res) }
 
-std::pmr::string
+std::pmr::string *
 Tracer::EvaluateDebugConsoleExpression(const std::string &expression, bool escapeOutput,
-                                       std::pmr::memory_resource *allocator) noexcept
+                                       Allocator *allocator) noexcept
 {
-  // TODO(simon): write a simple interpreter for custom CLI-like commands. For now, do the absolute dumbest thing
-  // of all.
   auto res = mConsoleCommandInterpreter->Interpret(expression, allocator);
   return res.mContents;
 }
@@ -749,7 +747,7 @@ Tracer::MainLoop(EventSystem *eventSystem, mdb::js::AppScriptingInstance *script
           }
         } break;
         case EventType::Command: {
-          Tracer::Get().handle_command(evt.uCommand);
+          Tracer::Get().ExecuteCommand(evt.uCommand);
         } break;
         case EventType::TraceeEvent: {
           Tracer::Get().HandleTracerEvent(evt.uDebugger);

--- a/src/tracer.h
+++ b/src/tracer.h
@@ -128,12 +128,12 @@ public:
   void config_done(ui::dap::DebugAdapterClient *client) noexcept;
   TraceEvent *ConvertWaitEvent(TaskWaitResult wait_res) noexcept;
   Ref<TaskInfo> TakeUninitializedTask(Tid tid) noexcept;
-  void handle_command(ui::UICommand *cmd) noexcept;
+  void ExecuteCommand(ui::UICommand *cmd) noexcept;
   void HandleTracerEvent(TraceEvent *evt) noexcept;
   void HandleInternalEvent(InternalEvent evt) noexcept;
   void HandleInitEvent(TraceEvent *evt) noexcept;
-  std::pmr::string EvaluateDebugConsoleExpression(const std::string &expression, bool escapeOutput,
-                                                  std::pmr::memory_resource *allocator) noexcept;
+  std::pmr::string *EvaluateDebugConsoleExpression(const std::string &expression, bool escapeOutput,
+                                                   Allocator *allocator) noexcept;
 
   void SetUI(ui::dap::DAP *dap) noexcept;
   void KillUI() noexcept;

--- a/src/typedefs.h
+++ b/src/typedefs.h
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <memory_resource>
 #include <string_view>
 #include <sys/types.h>
 #include <tuple>
@@ -20,6 +21,8 @@ using i8 = std::int8_t;
 
 using Tid = pid_t;
 using Pid = pid_t;
+
+using Allocator = std::pmr::polymorphic_allocator<>;
 
 template <typename Fn, typename... FnArgs> using FnResult = std::invoke_result_t<Fn, FnArgs...>;
 


### PR DESCRIPTION
This is supposed to be a thin wrapper around string views, to be passed to formatting operations like so: `fmt::format("{}", DapStringView{str});` and it will handle the escaping during formatting.

If we don't escape strings responses and results may not be caught by the client.