### PR TITLE
Fixed bug

### DIFF
--- a/src/interface/tracee_command/supervisor_state.cpp
+++ b/src/interface/tracee_command/supervisor_state.cpp
@@ -1220,7 +1220,7 @@ SupervisorState::FindFunctionByPc(AddrPtr addr) noexcept
     "supervisor",
     PEARG("cu_count", matchingCompilationUnits.size()),
     PEARG("unreloc_addr", symbolFile->UnrelocateAddress(addr)),
-    PEARG("found_fn", foundFn ? foundFn->name : "not found"));
+    PEARG("found_fn", foundFn ? foundFn->mName : "not found"));
 
   using sym::CompilationUnit;
 

--- a/src/symbolication/callstack.cpp
+++ b/src/symbolication/callstack.cpp
@@ -70,7 +70,7 @@ Frame::FrameId() const noexcept
 int
 Frame::FrameLevel() const noexcept
 {
-  return mFrameLevel;
+  return static_cast<int>(mFrameLevel);
 }
 
 AddrPtr
@@ -124,7 +124,7 @@ Frame::Scopes() noexcept
 {
   // Variable reference can't be 0, so a zero here, means we haven't created the scopes yet
   if (mFrameScopes[0].variables_reference == 0) {
-    for (auto i = 0u; i < 3; ++i) {
+    for (size_t i = 0; i < 3; ++i) {
       mFrameScopes[i].type = static_cast<ui::dap::ScopeType>(i);
       const auto key = Tracer::NewVariablesReference();
       Tracer::SetVariableContext(
@@ -215,7 +215,7 @@ Frame::GetFunctionName() const noexcept
 {
   switch (mFrameType) {
   case FrameType::Full:
-    return mSymbolUnion.uFullSymbol->name;
+    return mSymbolUnion.uFullSymbol->mName;
   case FrameType::ElfSymbol:
     return mSymbolUnion.uMinSymbol->name;
   case FrameType::Unknown:
@@ -296,7 +296,7 @@ CallStack::GetFrameAtLevel(u32 level) noexcept
   if (level >= mStackFrames.size()) {
     return nullptr;
   }
-  return &mStackFrames[0];
+  return mStackFrames.data();
 }
 
 u64
@@ -405,7 +405,7 @@ CallStack::GetCurrent() noexcept
     return { nullptr, nullptr };
   }
   auto span = std::span{ mUnwoundRegister }.subspan(mUnwoundRegister.size() - 2, 2);
-  return { &span[0], &span[1] };
+  return { span.data(), span.data() + 1 };
 }
 
 bool

--- a/src/symbolication/dwarf/typeread.cpp
+++ b/src/symbolication/dwarf/typeread.cpp
@@ -1,16 +1,17 @@
 /** LICENSE TEMPLATE */
 #include "typeread.h"
-#include "lib/static_vector.h"
-#include "symbolication/block.h"
-#include "symbolication/dwarf/attribute_read.h"
-#include "symbolication/dwarf/debug_info_reader.h"
-#include "symbolication/dwarf/die_iterator.h"
-#include "symbolication/dwarf_attribute_value.h"
-#include "symbolication/dwarf_defs.h"
-#include "symbolication/type.h"
-#include "utils/logger.h"
+
+// mdb
+#include <symbolication/block.h>
 #include <symbolication/callstack.h>
+#include <symbolication/dwarf/attribute_read.h>
+#include <symbolication/dwarf/debug_info_reader.h>
+#include <symbolication/dwarf/die_iterator.h>
+#include <symbolication/dwarf_attribute_value.h>
+#include <symbolication/dwarf_defs.h>
 #include <symbolication/objfile.h>
+#include <symbolication/type.h>
+#include <utils/logger.h>
 
 namespace mdb::sym::dw {
 
@@ -200,7 +201,7 @@ FunctionSymbolicationContext::ProcessSymbolInformation() noexcept
 {
   PROFILE_SCOPE_ARGS("FunctionSymbolicationContext::ProcessSymbolInformation",
     "symbolication",
-    PEARG("function", this->mFunctionSymbol->name));
+    PEARG("function", this->mFunctionSymbol->mName));
   if (mFunctionSymbol->IsResolved()) {
     return;
   }

--- a/src/symbolication/fnsymbol.cpp
+++ b/src/symbolication/fnsymbol.cpp
@@ -14,16 +14,15 @@ DetermineArchitectureReturnClass(sym::Type *type) noexcept
 FunctionSymbol::FunctionSymbol(AddrPtr start,
   AddrPtr end,
   std::string_view name,
-  std::string_view member_of,
-  sym::Type *return_type,
-  std::array<dw::IndexedDieReference, 3> maybe_origin,
-  CompilationUnit &decl_file,
-  std::span<const u8> fb_expr,
+  std::string_view memberOf,
+  sym::Type *returnType,
+  std::array<dw::IndexedDieReference, 3> maybeOrigin,
+  CompilationUnit &declFile,
+  std::span<const u8> fbExpr,
   std::optional<SourceCoordinate> &&source) noexcept
-    : mDeclaringCompilationUnit(NonNull(decl_file)), mFormalParametersBlock({ { start, end } }, {}),
-      mFunctionSymbolBlocks(), mMaybeOriginDies(maybe_origin), mFrameBaseDwarfExpression(fb_expr),
-      mFunctionReturnType(return_type), pc_start(start), pc_end_exclusive(end), member_of(member_of), name(name),
-      source(std::move(source))
+    : mDeclaringCompilationUnit(NonNull(declFile)), mFormalParametersBlock({ { start, end } }, {}),
+      mMaybeOriginDies(maybeOrigin), mFrameBaseDwarfExpression(fbExpr), mFunctionReturnType(returnType),
+      mStartPc(start), mExclusiveEndPc(end), mMemberOf(memberOf), mName(name), mSource(std::move(source))
 {
 }
 
@@ -32,20 +31,21 @@ FunctionSymbol::FunctionSymbol(FunctionSymbol &&fn) noexcept
       mFormalParametersBlock(std::move(fn.mFormalParametersBlock)),
       mFunctionSymbolBlocks(std::move(fn.mFunctionSymbolBlocks)), mMaybeOriginDies(fn.mMaybeOriginDies),
       mFrameBaseDwarfExpression(fn.mFrameBaseDwarfExpression), mFunctionReturnType(fn.mFunctionReturnType),
-      pc_start(fn.pc_start), pc_end_exclusive(fn.pc_end_exclusive), member_of(fn.member_of), name(fn.name),
-      source(std::move(fn.source))
+      mStartPc(fn.mStartPc), mExclusiveEndPc(fn.mExclusiveEndPc), mMemberOf(fn.mMemberOf), mName(fn.mName),
+      mSource(std::move(fn.mSource))
 {
 }
 
 AddrPtr
 FunctionSymbol::StartPc() const noexcept
 {
-  return pc_start;
+  return *mStartPc;
 }
+
 AddrPtr
 FunctionSymbol::EndPc() const noexcept
 {
-  return pc_end_exclusive;
+  return *mExclusiveEndPc;
 }
 
 CompilationUnit *
@@ -57,13 +57,12 @@ FunctionSymbol::GetCompilationUnit() noexcept
 std::span<const dw::IndexedDieReference>
 FunctionSymbol::OriginDebugInfoEntries() const noexcept
 {
-  auto &dies = *mMaybeOriginDies;
-  for (auto i = 0u; i < dies.size(); ++i) {
-    if (!dies[i].IsValid()) {
-      return std::span{ dies.begin(), dies.begin() + i };
+  for (size_t i = 0; i < mMaybeOriginDies->size(); ++i) {
+    if (!mMaybeOriginDies[i].IsValid()) {
+      return std::span{ mMaybeOriginDies->begin(), mMaybeOriginDies->begin() + i };
     }
   }
-  return dies;
+  return mMaybeOriginDies;
 }
 
 bool
@@ -132,7 +131,7 @@ IsSame(const FunctionSymbol *l, const FunctionSymbol *r) noexcept
 bool
 IsSame(const FunctionSymbol &l, const FunctionSymbol &r) noexcept
 {
-  return *l.name == *r.name && *l.pc_start == *r.pc_start && *l.pc_end_exclusive == *r.pc_end_exclusive;
+  return *l.mName == *r.mName && *l.mStartPc == *r.mStartPc && *l.mExclusiveEndPc == *r.mExclusiveEndPc;
 }
 
 } // namespace mdb::sym

--- a/src/symbolication/fnsymbol.h
+++ b/src/symbolication/fnsymbol.h
@@ -1,9 +1,10 @@
 /** LICENSE TEMPLATE */
 #pragma once
-#include "../common.h"
-#include "addr_sorter.h"
-#include "symbolication/type.h"
-#include "utils/immutable.h"
+// mdb
+#include <common.h>
+#include <symbolication/addr_sorter.h>
+#include <symbolication/type.h>
+#include <utils/immutable.h>
 
 namespace mdb::sym {
 namespace dw {
@@ -13,7 +14,7 @@ class CompilationUnit;
 
 struct ResolveFnSymbolState;
 
-enum class ReturnValueClass
+enum class ReturnValueClass : u8
 {
   ImplicitPointerToMemory,
   RaxRdxPair,
@@ -48,12 +49,12 @@ private:
   FunctionSymbol(AddrPtr start,
     AddrPtr end,
     std::string_view name,
-    std::string_view member_of,
-    sym::Type *return_type,
-    std::array<dw::IndexedDieReference, 3> maybe_origin,
-    CompilationUnit &decl_file,
-    std::span<const u8> fb_expr,
-    std::optional<SourceCoordinate> &&source_coord) noexcept;
+    std::string_view memberOf,
+    sym::Type *returnType,
+    std::array<dw::IndexedDieReference, 3> maybeOrigin,
+    CompilationUnit &declFile,
+    std::span<const u8> fbExpr,
+    std::optional<SourceCoordinate> &&sourceCoord) noexcept;
 
 public:
   // Only really used when constructing the full function symbols for a compilation unit, as std::vector grows, it
@@ -62,11 +63,11 @@ public:
   FunctionSymbol(FunctionSymbol &&fn) noexcept;
   FunctionSymbol &operator=(FunctionSymbol &&fn) noexcept = default;
 
-  Immutable<AddrPtr> pc_start;
-  Immutable<AddrPtr> pc_end_exclusive;
-  Immutable<std::string_view> member_of;
-  Immutable<std::string_view> name;
-  Immutable<std::optional<SourceCoordinate>> source;
+  Immutable<AddrPtr> mStartPc;
+  Immutable<AddrPtr> mExclusiveEndPc;
+  Immutable<std::string_view> mMemberOf;
+  Immutable<std::string_view> mName;
+  Immutable<std::optional<SourceCoordinate>> mSource;
 
   AddrPtr StartPc() const noexcept;
   AddrPtr EndPc() const noexcept;
@@ -123,6 +124,6 @@ template <> struct std::formatter<sym::FunctionSymbol>
   auto
   format(const sym::FunctionSymbol &var, FormatContext &ctx) const
   {
-    return std::format_to(ctx.out(), "fn={}, [{} .. {}]", var.name, var.StartPc(), var.EndPc());
+    return std::format_to(ctx.out(), "fn={}, [{} .. {}]", var.mName, var.StartPc(), var.EndPc());
   }
 };

--- a/src/task_scheduling.cpp
+++ b/src/task_scheduling.cpp
@@ -332,17 +332,16 @@ StepInto::Create(tc::SupervisorState &ctrl, TaskInfo &task) noexcept
 
   auto compilationUnits = symbolFile->GetCompilationUnits(framePc);
 
-  for (auto compilationUnit : compilationUnits) {
-    const auto [sourceCodeFile, lineTableEntry] =
-      compilationUnit->GetLineTableEntry(symbolFile->UnrelocateAddress(framePc));
+  for (sym::CompilationUnit *compilationUnit : compilationUnits) {
+    const auto unrelocatedAddr = symbolFile->UnrelocateAddress(framePc);
+    const auto [sourceCodeFile, lineTableEntry] = compilationUnit->GetLineTableEntry(unrelocatedAddr);
     if (sourceCodeFile && lineTableEntry) {
       const auto relocPc = lineTableEntry->RelocateProgramCounter(symbolFile->mBaseAddress);
-      if (startFrame.IsInside(relocPc) == sym::InsideRange::Yes) {
+      if (startFrame.IsInside(unrelocatedAddr) == sym::InsideRange::Yes) {
         if (relocPc == framePc) {
           return std::make_shared<StepInto>(ctrl, task, startFrame, *lineTableEntry);
-        } else {
-          return std::make_shared<StepInto>(ctrl, task, startFrame, *(lineTableEntry - 1));
         }
+        return std::make_shared<StepInto>(ctrl, task, startFrame, *(lineTableEntry - 1));
       }
     }
   }

--- a/src/utils/immutable.h
+++ b/src/utils/immutable.h
@@ -183,6 +183,16 @@ public:
   {
     return mData;
   }
+
+  template <typename Index>
+  constexpr auto
+  operator[](Index &&idx) const
+    requires requires(const T &t, Index i) {
+      { t[i] };
+    }
+  {
+    return mData[std::forward<Index>(idx)];
+  }
 };
 
 template <> class Immutable<std::string>
@@ -266,6 +276,12 @@ public:
     }
 
     return std::string_view{ mData }.substr(index + 1);
+  }
+
+  constexpr auto
+  operator[](std::size_t idx) const noexcept
+  {
+    return mData[idx];
   }
 };
 


### PR DESCRIPTION
Conversion from relocated ("live") address to unrelocated was only performed once, when a second lookup which requires an unreloc addr was passed a relocated one.

Commit also addresses some clang-tidy issues at the same time.